### PR TITLE
fix: 会话报废与上下文超限两个根因

### DIFF
--- a/src/agent/session.py
+++ b/src/agent/session.py
@@ -1812,13 +1812,31 @@ class AgentSession:
                 # 返回空字符串，不抛出异常，让 ws_handlers 正常推送 chain_end
                 return ""
             else:
-                # 其他 BadRequestError，按通用异常处理
+                # 其他 BadRequestError
                 self._logger.debug(
                     "[SESSION] _invoke_graph BadRequestError: session=%s, error=%s",
                     self.session_id, type(e).__name__,
                 )
                 self._logger.error(f"Graph invoke BadRequestError: {e}", exc_info=True)
                 error_message = self._record_terminal_error(e)
+                if self.session_type == "main":
+                    # 修复：主会话 400 不杀会话——回滚该轮（清理悬空 tool_calls）、
+                    # 保持 running，用户可原样重发（下轮输入重新构造，400 大概率消失）
+                    self.status = "running"
+                    await self._rollback_on_error(sanitize_pairs=True, sync_snapshot=False)
+                    if event_callback:
+                        try:
+                            await event_callback({
+                                "type": "error",
+                                "session_id": self.session_id,
+                                "message": error_message,
+                                "terminal": False,
+                                "messages": self._visible_record(),
+                            })
+                        except Exception:
+                            pass
+                    return ""
+                # 子会话：保持原行为（error 终态 + raise，让 workflow 节点感知失败）
                 self.status = "error"
                 await self._rollback_on_error(sanitize_pairs=True, sync_snapshot=False)
                 if event_callback:
@@ -1878,8 +1896,27 @@ class AgentSession:
             self._logger.error(f"Graph invoke 错误: {e}", exc_info=True)
 
             error_message = self._record_terminal_error(e)
-            self.status = "error"
 
+            if self.session_type == "main":
+                # 修复：主会话瞬态失败（网络/超时/限流/流中断）不杀会话——
+                # 回滚该轮用户消息、保持 running、提示重发，会话不报废。
+                self.status = "running"
+                await self._rollback_on_error(sanitize_pairs=True)
+                if event_callback:
+                    try:
+                        await event_callback({
+                            "type": "error",
+                            "session_id": self.session_id,
+                            "message": error_message,
+                            "terminal": False,
+                            "messages": self._visible_record(),
+                        })
+                    except Exception:
+                        pass  # event_callback 可能因 WS 断线失败，不影响主流程
+                return ""
+
+            # 子会话：保持原行为（error 终态 + raise，让 workflow 节点感知失败）
+            self.status = "error"
             await self._rollback_on_error(sanitize_pairs=True)
 
             # 事件已通过非阻塞队列投递，无需等待

--- a/src/agent/session_manager.py
+++ b/src/agent/session_manager.py
@@ -22,6 +22,7 @@ from src.agent.session_catalog import SessionCatalog
 from src.agent.session_lifecycle import SessionLifecycleMixin
 from src.core.change_broadcaster import ChangeBroadcaster
 from langgraph.errors import GraphRecursionError
+from langchain_core.messages import SystemMessage
 
 from src.core.utils import is_visible_to_frontend
 from src.extension_api import PromptContextRequest
@@ -239,7 +240,7 @@ class SessionManager(SessionLifecycleMixin):
             workflow_id=workflow_id,
         ))
 
-    async def create_main_session(self, llm_client=None, agent_type: str = "main") -> dict:
+    async def create_main_session(self, llm_client=None, agent_type: str = "main", from_session_id: str | None = None) -> dict:
         """创建新的主会话（用于前端主动创建新会话）。
 
         支持指定任意 agent_type（如 "coder"、"researcher" 等），
@@ -247,6 +248,9 @@ class SessionManager(SessionLifecycleMixin):
 
         多 main 并存：旧主会话不会被停止，新老 main 同时运行。
         通过 PromptBuilder + ToolAssembler 统一流程。
+
+        from_session_id: 可选。指定后新主会话继承该主会话的对话上下文
+        （lc_messages 对话部分）与 workspace_path，实现"新会话接手旧会话工作"。
         """
         from src.agent.definition import get_agent_definition
 
@@ -306,6 +310,33 @@ class SessionManager(SessionLifecycleMixin):
                 )
         else:
             new_session.system_prompt = self._build_main_prompt_fallback(new_session)
+
+        # 3.5 继承旧会话上下文（from_session_id：新主会话接手旧会话的对话与工作区）
+        if from_session_id:
+            source = self.get_session(from_session_id)
+            if source is not None and source.session_type == "main":
+                inherited = [
+                    m for m in source.lc_messages
+                    if not isinstance(m, SystemMessage)
+                ]
+                if inherited:
+                    new_session.lc_messages.extend(inherited)
+                if not new_session.workspace_path and source.workspace_path:
+                    new_session.workspace_path = source.workspace_path
+                if source.record:
+                    new_session.record = [
+                        r for r in source.record
+                        if isinstance(r, dict) and r.get("type") not in ("system",)
+                    ]
+                logger.info(
+                    f"新主会话 {new_session.session_id} 继承自 {from_session_id}: "
+                    f"{len(inherited)} 条对话消息, "
+                    f"workspace={new_session.workspace_path or '默认'}"
+                )
+            else:
+                logger.warning(
+                    f"from_session_id={from_session_id} 不是有效主会话，跳过继承"
+                )
 
         # 4. 注册 session
         self.register_main(new_session)
@@ -828,6 +859,46 @@ class SessionManager(SessionLifecycleMixin):
     # 统一消息发送入口
     # ============================================================
 
+    async def recover_session(self, session_id: str) -> dict:
+        """恢复 error 主会话：重编译 Graph、状态回 running，可继续对话。
+
+        修复：此前 LLM 瞬态失败会把主会话置为 error 终态且无恢复入口，
+        只能新建会话。本方法让 error 主会话回到可发送状态（回滚已在
+        _invoke_graph 完成，消息历史保持干净）。
+        """
+        session = self.sessions.get(session_id)
+        if not session:
+            return {"success": False, "message": f"未找到会话 {session_id}"}
+        if session.session_type != "main":
+            return {"success": False, "message": "仅支持恢复主会话"}
+        if session.status != "error":
+            return {"success": True, "message": "会话无需恢复"}
+
+        from src.core.llm_client import create_startup_llm
+
+        async with session._invoke_lock:
+            if session.invocation_active:
+                return {"success": False, "message": "会话正在生成中，请稍后恢复"}
+            # 重建 LLM（model_id 为空时跟随当前默认模型）并重编译 Graph
+            llm = create_startup_llm(
+                model_override=session.model_id,
+                streaming=True,
+                model_params=session.model_params,
+            )
+            session.setup_graph(llm=llm, tools=session.tools)
+            session.status = "running"
+            session.last_error = None
+            session.updated_at = datetime.now(timezone.utc).isoformat()
+            await session.async_save()
+
+        _try_emit_event({
+            "type": "session_update",
+            "action": "status_changed",
+            "session_id": session_id,
+            "status": "running",
+        })
+        return {"success": True, "message": "会话已恢复，可以继续对话"}
+
     async def send_message_to_session(
         self,
         session_id: str,
@@ -858,7 +929,12 @@ class SessionManager(SessionLifecycleMixin):
             return {"success": False, "message": f"会话 {session_id} 的 Graph 未初始化"}
 
         if session.status == "error":
-            return {"success": False, "message": f"会话 {session_id} 状态为 error，无法发送消息"}
+            # 修复：主会话 error 自动恢复后继续发送；子会话保持拒绝（workflow 场景）
+            if session.session_type == "main":
+                await self.recover_session(session_id)
+                session = self.sessions.get(session_id)
+            else:
+                return {"success": False, "message": f"会话 {session_id} 状态为 error，无法发送消息"}
 
         # 如果当前正在 streaming，等待一下（或拒绝）
         if session.status == "streaming":
@@ -907,7 +983,12 @@ class SessionManager(SessionLifecycleMixin):
             return {"success": False, "message": f"会话 {session_id} 的 Graph 未初始化"}
 
         if session.status == "error":
-            return {"success": False, "message": f"会话 {session_id} 状态为 error，无法编辑消息"}
+            # 修复：主会话 error 自动恢复后继续编辑；子会话保持拒绝
+            if session.session_type == "main":
+                await self.recover_session(session_id)
+                session = self.sessions.get(session_id)
+            else:
+                return {"success": False, "message": f"会话 {session_id} 状态为 error，无法编辑消息"}
 
         if session.status == "streaming":
             return {"success": False, "message": f"会话 {session_id} 正在流式输出中，无法编辑消息"}

--- a/src/compression/strategies/full.py
+++ b/src/compression/strategies/full.py
@@ -19,6 +19,11 @@ from src.prompts.compressor_prompts import build_compressor_prompt
 
 logger = logging.getLogger(__name__)
 
+# 修复：摘要 prompt 单条消息长度上限（字符）。tool 结果上限更严，
+# 因为工作流工具结果可能达到数十万字符。
+MAX_MESSAGE_CHARS = 3000
+MAX_TOOL_RESULT_CHARS = 1500
+
 
 class FullCompactStrategy:
     """
@@ -84,7 +89,9 @@ class FullCompactStrategy:
 
         if not summary:
             logger.warning("摘要生成失败，返回原始消息")
-            return messages
+            # 修复：失败兜底——截断超长消息后再返回。否则超限上下文原样保留，
+            # 下次压缩同样失败，会话因 400 超限报废（曾实测 130 万 token）。
+            return self._truncate_oversized(messages)
 
         # 构建新messages
         new_messages = self._build_new_messages(
@@ -235,6 +242,20 @@ class FullCompactStrategy:
             role = self._get_message_role(msg)
             msg_content = msg.content if isinstance(msg.content, str) else str(msg.content)
 
+            # 修复：摘要 prompt 截断超长消息——此前巨型 tool 结果（可达 60 万字符）
+            # 全文拼进摘要 prompt，使摘要生成请求本身超限（实测 165 万 token > 104 万
+            # 上限）→ 压缩失败 → 上下文永远无法瘦身 → 会话 400 超限报废。
+            if role == "tool" and len(msg_content) > MAX_TOOL_RESULT_CHARS:
+                msg_content = (
+                    msg_content[:MAX_TOOL_RESULT_CHARS]
+                    + f"\n...[工具结果过长已截断，原 {len(msg_content)} 字符]"
+                )
+            elif len(msg_content) > MAX_MESSAGE_CHARS:
+                msg_content = (
+                    msg_content[:MAX_MESSAGE_CHARS]
+                    + f"\n...[消息过长已截断，原 {len(msg_content)} 字符]"
+                )
+
             # 添加角色标识
             if role == "user":
                 content_parts.append(f"[用户消息]\n{msg_content}")
@@ -260,6 +281,41 @@ class FullCompactStrategy:
     def _get_message_role(self, msg: BaseMessage) -> str:
         """获取消息角色（委托给公共函数）"""
         return get_message_role(msg)
+
+    def _truncate_oversized(
+        self, messages: List[BaseMessage],
+    ) -> List[BaseMessage]:
+        """摘要失败兜底：把超长消息截断后返回，让上下文能瘦下来。"""
+        import copy as _copy
+
+        truncated_count = 0
+        cleaned: List[BaseMessage] = []
+        for msg in messages:
+            role = self._get_message_role(msg)
+            content = msg.content if isinstance(msg.content, str) else None
+            limit = (
+                MAX_TOOL_RESULT_CHARS if role == "tool" else MAX_MESSAGE_CHARS
+            )
+            if content is not None and len(content) > limit:
+                copy = _copy.copy(msg)
+                copy.content = (
+                    content[:limit]
+                    + f"\n...[内容过长已截断，原 {len(content)} 字符]"
+                )
+                cleaned.append(copy)
+                truncated_count += 1
+            else:
+                cleaned.append(msg)
+        if truncated_count:
+            logger.warning(
+                "摘要失败兜底截断 %d 条超长消息（合计约 %d 字符）",
+                truncated_count,
+                sum(
+                    len(m.content) if isinstance(m.content, str) else 0
+                    for m in messages
+                ),
+            )
+        return cleaned
 
     def _extract_summary(self, content: str) -> Optional[str]:
         """

--- a/src/web/api_routes.py
+++ b/src/web/api_routes.py
@@ -61,6 +61,7 @@ class SendMessageRequest(BaseModel):
 class CreateMainSessionRequest(BaseModel):
 
     agent_type: str = "main"
+    from_session_id: str | None = None
 
 
 class UpdateSessionModelRequest(BaseModel):
@@ -473,10 +474,12 @@ async def delete_session(session_id: str, request: Request):
 
 @router.post("/sessions/main/new")
 async def create_new_main_session(body: CreateMainSessionRequest, request: Request):
-    """创建新的主会话（前端主动触发），支持指定 agent_type"""
+    """创建新的主会话（前端主动触发），支持指定 agent_type 与 from_session_id（继承旧会话上下文）"""
     sm = _get_session_manager(request)
     llm = getattr(request.app.state, "llm", None)
-    result = await sm.create_main_session(llm_client=llm, agent_type=body.agent_type)
+    result = await sm.create_main_session(
+        llm_client=llm, agent_type=body.agent_type, from_session_id=body.from_session_id
+    )
     return result
 
 

--- a/src/web/ws_handlers.py
+++ b/src/web/ws_handlers.py
@@ -129,7 +129,17 @@ async def _validate_session(session_mgr, session_id: str, action_label: str):
     if session.compiled_graph is None:
         return None, {"type": "error", "message": f"会话 {session_id} Graph 未初始化", "session_id": session_id, "terminal": False}
     if session.status == "error":
-        return None, {"type": "error", "message": f"会话 {session_id} 状态为 error，无法{action_label}", "session_id": session_id, "terminal": False}
+        # 修复：主会话 error 自动恢复后继续操作；子会话保持拒绝（workflow 场景）
+        if session.session_type == "main":
+            try:
+                await session_mgr.recover_session(session_id)
+            except Exception:  # noqa: BLE001
+                return None, {"type": "error", "message": f"会话 {session_id} 恢复失败，请稍后再试", "session_id": session_id, "terminal": False}
+            session = session_mgr.get_session(session_id)
+            if session is None:
+                return None, {"type": "error", "message": f"未找到会话 {session_id}", "session_id": session_id, "terminal": False}
+        else:
+            return None, {"type": "error", "message": f"会话 {session_id} 状态为 error，无法{action_label}", "session_id": session_id, "terminal": False}
     if session.status == "streaming" or session.invocation_active:
         return None, {"type": "error", "message": f"会话 {session_id} 正在处理中，请稍后再试", "session_id": session_id, "terminal": False}
     return session, None
@@ -186,20 +196,30 @@ async def _execute_with_events(session, session_id: str, action_coro, action_lab
             })
     except Exception as e:
         logger.error(f"会话 {session_id} {action_label}失败: {e}", exc_info=True)
-        terminal_already_emitted = session.status == "error"
-        session.status = "error"
-        if not terminal_already_emitted:
+        if session.status == "error":
+            # 子会话已由 _invoke_graph 置为 error 终态（让 workflow 感知失败），
+            # 这里不重复处理，避免覆盖已发出的 error 事件。
+            return
+        # 修复：外层异常不再把会话置为 error 终态——主会话失败后保持可重发。
+        # 回滚该轮残留（_rollback_on_error 内部判断消息类型，安全幂等）。
+        try:
+            await session._rollback_on_error()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
             error_message = session._record_terminal_error(e)
-            await event_bus.emit_chat({
-                "type": "error",
-                "message": error_message,
-                "session_id": session_id,
-                "terminal": True,
-                "messages": [
-                    message for message in session.record
-                    if is_visible_to_frontend(message)
-                ],
-            })
+        except Exception:  # noqa: BLE001
+            error_message = str(e)
+        await event_bus.emit_chat({
+            "type": "error",
+            "message": error_message,
+            "session_id": session_id,
+            "terminal": False,
+            "messages": [
+                message for message in session.record
+                if is_visible_to_frontend(message)
+            ],
+        })
     finally:
         session.updated_at = datetime.now(timezone.utc).isoformat()
         await session.async_save()

--- a/src/workflow/tools.py
+++ b/src/workflow/tools.py
@@ -53,6 +53,43 @@ def _internal_only_failure(workflow_id: str) -> str:
     )
 
 
+def _strip_node_outputs(task: dict) -> dict:
+    """去掉 task node_states 里的 outputs/stdout/stderr 全文，只留进度元数据。
+
+    修复：list_tasks 此前返回 task.to_dict() 的完整 node_states（含各节点
+    outputs/stdout/stderr 全文），工作流单次运行即可产生数十万字符的工具结果，
+    主会话反复调用 list_tasks 轮询会迅速撑爆上下文（曾实测 130 万 token > 104 万
+    上限，导致会话 400 超限报废）。get_task_status 已做轻量化，这里与之一致。
+    """
+    node_states = task.get("node_states") or {}
+    light: dict[str, dict] = {}
+    for nid, node in node_states.items():
+        if not isinstance(node, dict):
+            light[nid] = node  # type: ignore[assignment]
+            continue
+        light[nid] = {
+            key: node.get(key)
+            for key in (
+                "node_id",
+                "status",
+                "summary",
+                "error",
+                "attempt_count",
+                "automatic_retry_count",
+                "next_retry_at",
+                "available_actions",
+                "started_at",
+                "completed_at",
+                "rejection_count",
+                "rejection_reason",
+                "reject_upstream_count",
+            )
+        }
+    cleaned = dict(task)
+    cleaned["node_states"] = light
+    return cleaned
+
+
 def _policy_unavailable_failure(workflow_id: str) -> str:
     """Fail closed when a tool cannot establish a workflow's policy."""
     return _fail(
@@ -860,7 +897,7 @@ def create_list_tasks_tool(
                 )
                 if task_policy_error:
                     continue
-                visible_tasks.append(task)
+                visible_tasks.append(_strip_node_outputs(task))
             return _ok(
                 workflow_id=workflow_id,
                 tasks=visible_tasks,

--- a/tests/test_chat_stream_protocol.py
+++ b/tests/test_chat_stream_protocol.py
@@ -994,7 +994,10 @@ def test_abort_during_pre_stream_compression_never_starts_graph_or_stream():
         assert session.status == expected_status
 
 
-def test_terminal_errors_emit_authoritative_history_after_rollback():
+def test_errors_emit_authoritative_history_after_rollback():
+    """主会话失败（RuntimeError / BadRequestError）不报废：回滚该轮、事件
+    terminal=False、状态保持 running，用户可原样重发。"""
+
     async def scenario(error: Exception):
         partial_chunk = SimpleNamespace(content="partial", additional_kwargs={})
         graph = _EventGraph([
@@ -1031,10 +1034,7 @@ def test_terminal_errors_emit_authoritative_history_after_rollback():
 
         session.async_save = no_save
         session._check_and_compress_messages = no_compress
-        try:
-            await session.send_message("new question", capture, max_rounds=1)
-        except type(error):
-            pass
+        await session.send_message("new question", capture, max_rounds=1)
         return session, emitted, record_when_error_emitted
 
     bad_response = httpx.Response(
@@ -1052,7 +1052,8 @@ def test_terminal_errors_emit_authoritative_history_after_rollback():
     for error in errors:
         session, emitted, record_when_error_emitted = asyncio.run(scenario(error))
         terminal = next(event for event in emitted if event["type"] == "error")
-        assert terminal["terminal"] is True
+        # 修复后：主会话失败不报废——terminal=False、状态 running、历史已回滚
+        assert terminal["terminal"] is False
         assert terminal["messages"] == expected_history
         assert record_when_error_emitted == [[
             {"id": "system", "type": "system_prompt", "content": "hidden"},
@@ -1062,7 +1063,7 @@ def test_terminal_errors_emit_authoritative_history_after_rollback():
             {"id": "system", "type": "system_prompt", "content": "hidden"},
             *expected_history,
         ]
-        assert session.status == "error"
+        assert session.status == "running"
 
 
 def test_execute_wrapper_does_not_duplicate_session_terminal_error(monkeypatch):

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -1,0 +1,154 @@
+"""会话失败恢复回归测试。
+
+覆盖修复：
+- 主会话 LLM 瞬态失败（网络/超时/限流/流中断）→ 不再置 error 终态，会话保持
+  running 可继续；错误事件 terminal=False（前端提示重试而非报废）。
+- 子会话失败保持原行为（error 终态 + raise，workflow 节点感知失败）。
+- recover_session 把 error 主会话恢复为 running。
+- create_main_session(from_session_id=...) 继承旧主会话对话上下文与 workspace。
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.agent.session import AgentSession
+
+
+class FailingGraph:
+    """astream_events 直接抛异常的假图（模拟 LLM 网络中断/流式中断）。"""
+
+    async def astream_events(self, *args, **kwargs):
+        raise RuntimeError("模拟 LLM 网络中断")
+        yield  # pragma: no cover
+
+
+def _make_session(session_type="main"):
+    s = AgentSession(session_type=session_type, system_prompt="你是测试助手。")
+    s.compiled_graph = FailingGraph()
+    return s
+
+
+def test_main_session_failure_keeps_session_alive():
+    """主会话 LLM 失败 → 不置 error、不 raise、事件 terminal=False，可继续。"""
+    s = _make_session("main")
+    events = []
+
+    async def cb(event):
+        events.append(event)
+
+    async def run():
+        return await s._invoke_graph(content="你好", event_callback=cb, max_rounds=2)
+
+    result = asyncio.run(run())
+    assert result == ""  # 不抛出，返回空
+    assert s.status == "running"  # 会话未报废
+    errs = [e for e in events if e.get("type") == "error"]
+    assert errs, "应发出 error 事件提示用户"
+    assert errs[0].get("terminal") is False  # 非终态，可重试
+    assert s.last_error is not None  # 错误已记录
+
+
+def test_sub_session_failure_still_errors():
+    """子会话失败保持原行为：error 终态 + raise（workflow 节点感知失败）。"""
+    s = _make_session("sub")
+    events = []
+
+    async def cb(event):
+        events.append(event)
+
+    async def run():
+        return await s._invoke_graph(content="子任务", event_callback=cb, max_rounds=2)
+
+    with pytest.raises(RuntimeError, match="模拟 LLM 网络中断"):
+        asyncio.run(run())
+    assert s.status == "error"
+    errs = [e for e in events if e.get("type") == "error"]
+    assert errs and errs[0].get("terminal") is True
+
+
+def test_recover_error_main_session(monkeypatch):
+    """recover_session 把 error 主会话恢复为 running（不重建、不丢消息）。"""
+    from src.agent.session_manager import SessionManager
+
+    sm = SessionManager()
+    s = AgentSession(session_type="main", system_prompt="测试")
+    s.status = "error"
+    s.last_error = {"code": "x", "message": "旧错误"}
+    sm.sessions[s.session_id] = s
+
+    # 避免真实 LLM 构造与 graph 编译
+    monkeypatch.setattr(
+        "src.core.llm_client.create_startup_llm", lambda **kw: object()
+    )
+    monkeypatch.setattr(AgentSession, "setup_graph", lambda self, llm, tools: None)
+
+    async def run():
+        return await sm.recover_session(s.session_id)
+
+    result = asyncio.run(run())
+    assert result["success"]
+    assert s.status == "running"
+    assert s.last_error is None
+
+
+def test_recover_non_error_session_noop():
+    """非 error 会话 recover 是 no-op（不误伤）。"""
+    from src.agent.session_manager import SessionManager
+
+    sm = SessionManager()
+    s = AgentSession(session_type="main", system_prompt="测试")
+    s.status = "running"
+    sm.sessions[s.session_id] = s
+
+    async def run():
+        return await sm.recover_session(s.session_id)
+
+    result = asyncio.run(run())
+    assert result["success"]
+    assert s.status == "running"
+
+
+def test_create_main_session_inherits_context(monkeypatch):
+    """from_session_id 继承旧主会话对话上下文与 workspace。"""
+    from langchain_core.messages import HumanMessage
+
+    from src.agent.session_manager import SessionManager
+
+    sm = SessionManager()
+    old = AgentSession(
+        session_type="main", system_prompt="旧助手", workspace_path="/books/demo"
+    )
+    old.lc_messages.append(HumanMessage(content="之前的对话内容"))
+    sm.sessions[old.session_id] = old
+
+    monkeypatch.setattr(
+        "src.core.llm_client.create_startup_llm", lambda **kw: object()
+    )
+    monkeypatch.setattr(AgentSession, "setup_graph", lambda self, llm, tools: None)
+    monkeypatch.setattr(AgentSession, "start_consumer", lambda self: None)
+    monkeypatch.setattr(
+        SessionManager,
+        "_build_extension_prompt_context",
+        lambda self, agent_type, agent_def: "",
+    )
+
+    async def run():
+        return await sm.create_main_session(
+            llm_client=None, agent_type="main", from_session_id=old.session_id
+        )
+
+    result = asyncio.run(run())
+    assert result["success"]
+    new_s = sm.sessions[result["session_id"]]
+    # 继承对话上下文
+    assert any(
+        isinstance(m, HumanMessage) and m.content == "之前的对话内容"
+        for m in new_s.lc_messages
+    )
+    # 继承 workspace
+    assert new_s.workspace_path == "/books/demo"

--- a/tests/test_workflow_tool_context_guard.py
+++ b/tests/test_workflow_tool_context_guard.py
@@ -1,0 +1,81 @@
+"""上下文防护测试：list_tasks 轻量化 + 压缩摘要截断 + 失败兜底。
+
+背景：list_tasks 曾返回 task.to_dict() 的完整 node_states（含各节点
+outputs/stdout/stderr 全文），主会话反复轮询导致上下文被灌到 130 万 token，
+超过模型 104 万上限 → 400 超限 → 会话报废（压缩自救也因摘要超限失败）。
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from src.workflow.tools import _strip_node_outputs
+
+
+def test_strip_node_outputs_removes_heavy_fields():
+    task = {
+        "task_id": "t1",
+        "workflow_id": "w",
+        "status": "running",
+        "node_states": {
+            "n1": {
+                "status": "completed",
+                "outputs": "X" * 50_000,
+                "stdout": "Y" * 50_000,
+                "stderr": "Z" * 50_000,
+                "summary": "ok",
+                "attempt_count": 1,
+                "started_at": "2026-01-01",
+                "completed_at": "2026-01-02",
+            }
+        },
+    }
+    cleaned = _strip_node_outputs(task)
+    node = cleaned["node_states"]["n1"]
+    assert "outputs" not in node
+    assert "stdout" not in node
+    assert "stderr" not in node
+    assert node["summary"] == "ok"
+    assert node["status"] == "completed"
+    assert len(str(cleaned)) < 2_000
+
+
+def test_strip_node_outputs_preserves_task_meta():
+    task = {"task_id": "t1", "workflow_id": "w", "status": "running",
+            "node_states": {}, "name": "任务", "created_at": "2026-01-01"}
+    cleaned = _strip_node_outputs(task)
+    assert cleaned["task_id"] == "t1"
+    assert cleaned["workflow_id"] == "w"
+    assert cleaned["name"] == "任务"
+    assert cleaned["node_states"] == {}
+
+
+def test_prepare_user_content_truncates_huge_tool_result():
+    from src.compression.strategies.full import FullCompactStrategy
+
+    strategy = FullCompactStrategy()
+    huge_tool = ToolMessage(content="A" * 60_000, tool_call_id="call_1")
+    user = HumanMessage(content="你好")
+    content = strategy._prepare_user_content([huge_tool, user])
+    # 摘要 prompt 必须远小于巨型工具结果
+    assert len(content) < 5_000
+    assert "已截断" in content
+
+
+def test_truncate_oversized_fallback_trims_huge_messages():
+    from src.compression.strategies.full import FullCompactStrategy
+
+    strategy = FullCompactStrategy()
+    messages = [
+        SystemMessage(content="sys"),
+        ToolMessage(content="T" * 50_000, tool_call_id="call_1"),
+        HumanMessage(content="H" * 50_000),
+        AIMessage(content="正常回复"),
+    ]
+    cleaned = strategy._truncate_oversized(messages)
+    # 正常消息不动
+    assert cleaned[0].content == "sys"
+    assert cleaned[3].content == "正常回复"
+    # 超长消息被截断
+    assert len(str(cleaned[1].content)) < 3_000
+    assert len(str(cleaned[2].content)) < 4_000
+    assert "已截断" in str(cleaned[1].content)
+    assert "已截断" in str(cleaned[2].content)


### PR DESCRIPTION
问题 1：LLM 瞬态失败（网络/超时/限流/流中断）会把主会话置为 error 终态
并抛异常，会话报废无恢复入口。修复：main 会话失败回滚该轮、保持 running、
提示可重发（sub 会话保持原行为）；新增 recover_session 自动恢复入口；
新建主会话支持 from_session_id 继承旧会话上下文与工作区。

问题 2：list_tasks 工具返回 task 的完整 node_states（含各节点
outputs/stdout/stderr 全文），主会话反复轮询使上下文被灌到 130 万 token， 超过模型 104 万上限，每次调用 400 超限；压缩摘要也因读取超长消息而超限，
自救失败导致会话死锁。修复：list_tasks 返回前剥离 node_states 全文
（与 get_task_status 一致）；压缩摘要 prompt 截断超长消息；摘要失败兜底
截断超长消息，保证压缩永远能瘦身。

测试：tests/test_session_recovery.py（5 项）、
tests/test_workflow_tool_context_guard.py（4 项），
test_chat_stream_protocol.py 适配新行为。