### PR TITLE
fix: agent 节点空输出复用子会话重试，避免整条管线重跑

### DIFF
--- a/src/workflow/nodes/agent.py
+++ b/src/workflow/nodes/agent.py
@@ -192,6 +192,14 @@ class AgentNode(BaseNodePlugin):
                 "description": "JSON 校验失败后追加修复指令的最大次数",
             },
             {
+                "key": "retry_empty_output",
+                "label": "空输出自动重试",
+                "type": "boolean",
+                "required": False,
+                "default": True,
+                "description": "开启后，本轮 LLM 输出为空时复用同一子会话自动重试（只重跑当前节点，避免整条管线重跑）；重试不会触发工具调用。关闭则空输出直接判失败",
+            },
+            {
                 "key": "model_override",
                 "label": "模型覆盖",
                 "type": "select",
@@ -449,7 +457,7 @@ class AgentNode(BaseNodePlugin):
                 token_usage=node_token_usage,
             )
 
-        # 从 session 读取累计 token 消耗
+        # 从 session 读取累计 token 消耗（重试成功后需重新读取，见下方）
         node_token_usage = self._get_session_token_usage(sm, session_id)
 
         validation_enabled = bool(
@@ -457,48 +465,84 @@ class AgentNode(BaseNodePlugin):
             or json_output_field
             or json_output_field_min_chars
         )
-        validated_output = ""
-        if completion_result["status"] == "success" and validation_enabled:
-            validated_output = self._get_latest_ai_message(sm, session_id)
-            validation = validate_agent_output(
-                validated_output,
-                require_non_empty=require_non_empty_output,
-                json_field=json_output_field,
-                json_field_min_chars=json_output_field_min_chars,
-            )
-            if not validation.success:
-                return NodeResult(
-                    summary=completion_result["summary"],
-                    status="failed",
-                    error=f"LLM 输出校验失败: {validation.error}",
-                    session_id=session_id,
-                    outputs={},
-                    token_usage=node_token_usage,
-                )
+        # retry_empty_output：优先节点属性（definition 层），回退 node_params（前端表单）
+        _retry_flag = getattr(node_def, "retry_empty_output", None)
+        if _retry_flag is None:
+            _retry_flag = (node_def.node_params or {}).get("retry_empty_output", True)
+        retry_enabled = bool(_retry_flag)
 
-        # 构建 NodeResult，提取输出变量
         outputs: dict[str, str] = {}
-        if output_var_key and completion_result["status"] == "success":
-            last_msg = (
-                validated_output if validation_enabled
-                else self._get_last_ai_message(sm, session_id)
-            )
-            if last_msg:
-                outputs[output_var_key] = last_msg
+        last_output = ""
+
+        if completion_result["status"] == "success":
+            # 本轮最新 assistant 输出。语义：最新消息即本轮输出——最新为空时视为
+            # 空输出（触发重试），不得回退到更早的非空中间回复。
+            last_output = self._get_latest_ai_message(sm, session_id)
+
+            # ---- 空输出统一重试 ----
+            # 覆盖 require_non_empty_output / JSON 字段校验 / 仅 output_variable /
+            # save_output_to_file 全部路径：只要本轮输出为空且允许重试，就复用
+            # 同一子会话重试，避免失败后整条管线重跑。
+            if not last_output and retry_enabled:
+                last_output = await self._retry_empty_output(sm, session_id)
+                if last_output:
+                    # 重试消耗了 1~N 次模型调用，重新读取累计 token 用量，
+                    # 否则 NodeResult 计量与成本审计会少算。
+                    node_token_usage = self._get_session_token_usage(sm, session_id)
+                elif output_var_key or validation_enabled or (
+                    save_output_to_file and output_file_path_raw
+                ):
+                    # 节点要求输出但重试仍为空：判失败，不得以"成功"结束。
+                    return NodeResult(
+                        summary=completion_result["summary"],
+                        status="failed",
+                        error=(
+                            "LLM 输出为空，自动重试 "
+                            f"{self.EMPTY_OUTPUT_RETRY_COUNT} 次后仍无输出"
+                        ),
+                        session_id=session_id,
+                        outputs={},
+                        token_usage=self._get_session_token_usage(sm, session_id),
+                    )
+
+            # ---- 校验（require_non_empty / JSON 字段路径）----
+            if validation_enabled:
+                validation = validate_agent_output(
+                    last_output,
+                    require_non_empty=require_non_empty_output,
+                    json_field=json_output_field,
+                    json_field_min_chars=json_output_field_min_chars,
+                )
+                if not validation.success:
+                    return NodeResult(
+                        summary=completion_result["summary"],
+                        status="failed",
+                        error=f"LLM 输出校验失败: {validation.error}",
+                        session_id=session_id,
+                        outputs={},
+                        token_usage=node_token_usage,
+                    )
+
+            # ---- 输出变量提取（含重试结果写回）----
+            if output_var_key:
+                if last_output:
+                    outputs[output_var_key] = last_output
 
         # ---- 保存最后输出到文件 ----
         if save_output_to_file and output_file_path_raw and completion_result["status"] == "success":
-            last_msg_for_file = outputs.get(output_var_key) if output_var_key else \
-                (
-                    validated_output if validation_enabled
-                    else self._get_last_ai_message(sm, session_id)
-                )
+            last_msg_for_file = outputs.get(output_var_key) if output_var_key else last_output
             if not last_msg_for_file:
                 # 修复：模型偶发输出空 content（如 DeepSeek 推理模式只产出
                 # reasoning 而无正文）——此前直接判失败，会触发任务级恢复、
                 # 重跑整条管线（已完成节点被重复执行，实测要 3 次才成功）。
                 # 改为复用同一子会话重试，命中率高且只重跑当前节点。
                 last_msg_for_file = await self._retry_empty_output(sm, session_id)
+                if last_msg_for_file:
+                    # 重试消耗了模型调用，重新读取累计 token 用量
+                    node_token_usage = self._get_session_token_usage(sm, session_id)
+                    # 非 JSON 路径也把重试结果写回输出变量，下游节点才能引用
+                    if output_var_key:
+                        outputs[output_var_key] = last_msg_for_file
             if last_msg_for_file:
                 try:
                     # 解析路径中的 {{key}} 占位符
@@ -659,7 +703,7 @@ class AgentNode(BaseNodePlugin):
                     "meta": meta,
                 }
 
-            retry_output = self._get_last_ai_message(sm, session_id)
+            retry_output = self._get_latest_ai_message(sm, session_id)
             retry_result = validate_and_format_json(
                 retry_output,
                 repair=policy == "safe_repair_then_retry",
@@ -691,14 +735,21 @@ class AgentNode(BaseNodePlugin):
 
     # 空输出重试：模型偶发只输出 reasoning 而无正文（如 DeepSeek 推理模式）。
     # 复用同一子会话重试，避免失败后整个任务重跑。
+    # 注意：重试 prompt 显式禁止工具调用，避免复用带工具的子会话时再次触发
+    # 有副作用的工具（评审要求明确副作用边界）。
     EMPTY_OUTPUT_RETRY_COUNT = 2
     EMPTY_OUTPUT_RETRY_PROMPT = (
         "你的上一条回复内容为空。请基于之前的指令重新完整输出结果，"
-        "不要重复提问，不要输出任何解释，直接给出最终内容。"
+        "不要重复提问，不要调用任何工具，不要输出任何解释，直接给出最终内容。"
     )
 
     async def _retry_empty_output(self, sm, session_id: str) -> str:
-        """复用子会话重试空输出；全部失败返回空字符串。"""
+        """复用子会话重试空输出；全部失败返回空字符串。
+
+        判断重试结果必须读取【最新】 assistant 消息（_get_latest_ai_message）：
+        若重试后仍为空，说明重试失败，不得回退到更早的非空中间回复（否则会
+        把旧回复当成本轮最终输出，反而绕过重试）。
+        """
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
         if session is None or not hasattr(session, "send_message"):
             return ""
@@ -713,7 +764,7 @@ class AgentNode(BaseNodePlugin):
             except Exception:
                 logger.exception("空输出重试调用失败: session=%s", session_id)
                 break
-            text = self._get_last_ai_message(sm, session_id)
+            text = self._get_latest_ai_message(sm, session_id)
             if text:
                 logger.info(
                     "节点空输出重试第 %d 次成功: session=%s", attempt, session_id,
@@ -724,28 +775,15 @@ class AgentNode(BaseNodePlugin):
         return ""
 
     @staticmethod
-    def _get_last_ai_message(sm, session_id: str) -> str:
-        """从子会话 record 中提取最后一条非空 assistant 消息的文本。
-
-        兼容结构化 content（list 块）——统一经 message_content_text 转换，
-        避免模型输出块格式时误判为空。
-        """
-        session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
-        if not session:
-            return ""
-        for msg in reversed(session.record):
-            if msg.get("type") == "assistant":
-                text = message_content_text(msg.get("content"))
-                if text:
-                    return text
-        return ""
-
-    @staticmethod
     def _get_latest_ai_message(sm, session_id: str) -> str:
         """读取最新 assistant 消息；不得用更早的非空消息替代空输出。
 
         兼容结构化 content（list 块）——统一经 message_content_text 转换，
         否则 OpenAI 兼容接口返回 list 格式时会被误判为空输出。
+
+        语义约定：最新 assistant 消息即"本轮输出"——最新为空时必须视为空
+        输出（触发空输出重试），而不能回退到更早的非空中间回复，否则会绕过
+        重试并把旧内容当成本轮最终结果。
         """
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
         if not session:

--- a/src/workflow/nodes/agent.py
+++ b/src/workflow/nodes/agent.py
@@ -12,6 +12,7 @@ import logging
 import time
 
 from src.config import WORKFLOW_NODE_TIMEOUT_SECONDS
+from src.core.utils import message_content_text
 from src.workflow.json_output import (
     build_json_retry_prompt,
     detect_output_format,
@@ -492,6 +493,12 @@ class AgentNode(BaseNodePlugin):
                     validated_output if validation_enabled
                     else self._get_last_ai_message(sm, session_id)
                 )
+            if not last_msg_for_file:
+                # 修复：模型偶发输出空 content（如 DeepSeek 推理模式只产出
+                # reasoning 而无正文）——此前直接判失败，会触发任务级恢复、
+                # 重跑整条管线（已完成节点被重复执行，实测要 3 次才成功）。
+                # 改为复用同一子会话重试，命中率高且只重跑当前节点。
+                last_msg_for_file = await self._retry_empty_output(sm, session_id)
             if last_msg_for_file:
                 try:
                     # 解析路径中的 {{key}} 占位符
@@ -682,27 +689,70 @@ class AgentNode(BaseNodePlugin):
             note += f"；安全修复: {repairs}"
         return f"{summary}\n\n{note}" if summary else note
 
-    @staticmethod
-    def _get_last_ai_message(sm, session_id: str) -> str:
-        """从子会话 record 中提取最后一条 assistant 消息的文本。"""
+    # 空输出重试：模型偶发只输出 reasoning 而无正文（如 DeepSeek 推理模式）。
+    # 复用同一子会话重试，避免失败后整个任务重跑。
+    EMPTY_OUTPUT_RETRY_COUNT = 2
+    EMPTY_OUTPUT_RETRY_PROMPT = (
+        "你的上一条回复内容为空。请基于之前的指令重新完整输出结果，"
+        "不要重复提问，不要输出任何解释，直接给出最终内容。"
+    )
+
+    async def _retry_empty_output(self, sm, session_id: str) -> str:
+        """复用子会话重试空输出；全部失败返回空字符串。"""
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
-        if not session:
+        if session is None or not hasattr(session, "send_message"):
             return ""
-        for msg in reversed(session.record):
-            if msg.get("type") == "assistant" and msg.get("content"):
-                return msg["content"]
+        for attempt in range(1, self.EMPTY_OUTPUT_RETRY_COUNT + 1):
+            try:
+                await session.send_message(
+                    self.EMPTY_OUTPUT_RETRY_PROMPT,
+                    max_rounds=1,
+                    source="workflow_empty_output_retry",
+                    source_name="workflow_node",
+                )
+            except Exception:
+                logger.exception("空输出重试调用失败: session=%s", session_id)
+                break
+            text = self._get_last_ai_message(sm, session_id)
+            if text:
+                logger.info(
+                    "节点空输出重试第 %d 次成功: session=%s", attempt, session_id,
+                )
+                return text
+        logger.error("节点空输出重试 %d 次仍无输出: session=%s",
+                     self.EMPTY_OUTPUT_RETRY_COUNT, session_id)
         return ""
 
     @staticmethod
-    def _get_latest_ai_message(sm, session_id: str) -> str:
-        """读取最新 assistant 消息；不得用更早的非空消息替代空输出。"""
+    def _get_last_ai_message(sm, session_id: str) -> str:
+        """从子会话 record 中提取最后一条非空 assistant 消息的文本。
+
+        兼容结构化 content（list 块）——统一经 message_content_text 转换，
+        避免模型输出块格式时误判为空。
+        """
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
         if not session:
             return ""
         for msg in reversed(session.record):
             if msg.get("type") == "assistant":
-                content = msg.get("content")
-                return content if isinstance(content, str) else ""
+                text = message_content_text(msg.get("content"))
+                if text:
+                    return text
+        return ""
+
+    @staticmethod
+    def _get_latest_ai_message(sm, session_id: str) -> str:
+        """读取最新 assistant 消息；不得用更早的非空消息替代空输出。
+
+        兼容结构化 content（list 块）——统一经 message_content_text 转换，
+        否则 OpenAI 兼容接口返回 list 格式时会被误判为空输出。
+        """
+        session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
+        if not session:
+            return ""
+        for msg in reversed(session.record):
+            if msg.get("type") == "assistant":
+                return message_content_text(msg.get("content"))
         return ""
 
     @staticmethod

--- a/tests/test_agent_empty_output_retry.py
+++ b/tests/test_agent_empty_output_retry.py
@@ -40,7 +40,7 @@ def make_plugin():
     return AgentNode()
 
 
-def test_get_last_ai_message_skips_empty_and_handles_list():
+def test_get_latest_ai_message_skips_empty_and_handles_list():
     sm = FakeSM({
         "s1": FakeSession([
             {"id": "m1", "type": "user", "content": "指令"},
@@ -49,18 +49,20 @@ def test_get_last_ai_message_skips_empty_and_handles_list():
              "content": [{"type": "text", "text": "结构化正文"}]},
         ]),
     })
-    # 最后一条非空 assistant（list 结构）应被提取为文本
-    assert AgentNode._get_last_ai_message(sm, "s1") == "结构化正文"
+    # 最新 assistant（list 结构）应被提取为文本
+    assert AgentNode._get_latest_ai_message(sm, "s1") == "结构化正文"
 
 
-def test_get_last_ai_message_all_empty_returns_empty():
+def test_get_latest_ai_message_skips_user_and_returns_empty():
     sm = FakeSM({
         "s1": FakeSession([
-            {"id": "m1", "type": "assistant", "content": ""},
-            {"id": "m2", "type": "assistant", "content": []},
+            {"id": "m1", "type": "user", "content": "指令"},
+            {"id": "m2", "type": "assistant", "content": ""},
+            {"id": "m3", "type": "user", "content": "追问"},
         ]),
     })
-    assert AgentNode._get_last_ai_message(sm, "s1") == ""
+    # 最新 assistant 为空：不得回退到更早的非空 assistant
+    assert AgentNode._get_latest_ai_message(sm, "s1") == ""
 
 
 def test_get_latest_ai_message_handles_list_content():
@@ -119,3 +121,46 @@ def test_retry_empty_output_fails_after_all_attempts():
 def test_retry_empty_output_missing_session_returns_empty():
     plugin = make_plugin()
     assert asyncio.run(plugin._retry_empty_output(FakeSM({}), "ghost")) == ""
+
+
+def test_retry_empty_output_does_not_fall_back_to_older_nonempty():
+    """评审边界：最新为空但更早非空时，重试不得把旧中间回复当成本轮输出。"""
+    plugin = make_plugin()
+
+    class FirstRetryStillEmptySession(FakeSession):
+        async def send_message(self, message, max_rounds=1, **kwargs):
+            self.sent_messages.append(message)
+            # 重试后仍追加空 assistant（模拟持续空输出）
+            self.record.append(
+                {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+                 "content": ""}
+            )
+            return {"success": True}
+
+    # record: 较早的非空 assistant + 最新空 assistant
+    session = FirstRetryStillEmptySession([
+        {"id": "m1", "type": "assistant", "content": "较早的中间回复"},
+        {"id": "m2", "type": "assistant", "content": ""},
+    ])
+    sm = FakeSM({"s1": session})
+    text = asyncio.run(plugin._retry_empty_output(sm, "s1"))
+    # 重试全部失败 → 必须返回空，不能返回"较早的中间回复"
+    assert text == ""
+    assert len(session.sent_messages) == plugin.EMPTY_OUTPUT_RETRY_COUNT
+
+
+def test_retry_prompt_forbids_tool_calls():
+    """评审边界：重试复用带工具的子会话，prompt 必须显式禁止工具调用。"""
+    plugin = make_plugin()
+    assert "不要调用任何工具" in plugin.EMPTY_OUTPUT_RETRY_PROMPT
+
+
+def test_get_latest_ai_message_returns_empty_when_latest_is_empty():
+    """评审边界：最新 assistant 为空（更早非空）时返回空，触发重试而非绕过。"""
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant", "content": "早先输出"},
+            {"id": "m2", "type": "assistant", "content": ""},
+        ]),
+    })
+    assert AgentNode._get_latest_ai_message(sm, "s1") == ""

--- a/tests/test_agent_empty_output_retry.py
+++ b/tests/test_agent_empty_output_retry.py
@@ -1,0 +1,121 @@
+"""agent 节点空输出重试与消息提取兼容性测试。
+
+背景：专业润色（agent_pp）节点偶发失败——模型（DeepSeek 推理模式）输出空
+content，节点判"没有最终 AI 输出可保存"直接失败，触发任务级恢复重跑整条
+管线（已完成节点重复执行，实测 3 次才成功）。修复：复用同一子会话重试空
+输出；同时让消息提取兼容结构化 content（list 块）。
+"""
+
+import asyncio
+
+import pytest
+
+from src.workflow.nodes.agent import AgentNode
+
+
+class FakeSession:
+    """最小子会话桩：record + send_message。"""
+
+    def __init__(self, record=None):
+        self.record = list(record or [])
+        self.sent_messages = []
+
+    async def send_message(self, message, max_rounds=1, **kwargs):
+        self.sent_messages.append(message)
+        # 默认追加一条非空 assistant 回复
+        self.record.append(
+            {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+             "content": "重试后的完整输出"}
+        )
+        return {"success": True}
+
+
+class FakeSM:
+    def __init__(self, sessions):
+        self.sessions = sessions
+
+
+def make_plugin():
+    # AgentNodePlugin 是 async 方法集，无 __init__ 依赖，直接实例化
+    return AgentNode()
+
+
+def test_get_last_ai_message_skips_empty_and_handles_list():
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "user", "content": "指令"},
+            {"id": "m2", "type": "assistant", "content": ""},
+            {"id": "m3", "type": "assistant",
+             "content": [{"type": "text", "text": "结构化正文"}]},
+        ]),
+    })
+    # 最后一条非空 assistant（list 结构）应被提取为文本
+    assert AgentNode._get_last_ai_message(sm, "s1") == "结构化正文"
+
+
+def test_get_last_ai_message_all_empty_returns_empty():
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant", "content": ""},
+            {"id": "m2", "type": "assistant", "content": []},
+        ]),
+    })
+    assert AgentNode._get_last_ai_message(sm, "s1") == ""
+
+
+def test_get_latest_ai_message_handles_list_content():
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant",
+             "content": [{"type": "text", "text": "最新输出"}]},
+        ]),
+    })
+    assert AgentNode._get_latest_ai_message(sm, "s1") == "最新输出"
+
+
+def test_get_latest_ai_message_empty_content_returns_empty():
+    # 最新 assistant 为空时不得回退到更早消息
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant", "content": "早先输出"},
+            {"id": "m2", "type": "assistant", "content": ""},
+        ]),
+    })
+    assert AgentNode._get_latest_ai_message(sm, "s1") == ""
+
+
+def test_retry_empty_output_succeeds_on_first_retry():
+    plugin = make_plugin()
+    session = FakeSession([
+        {"id": "m1", "type": "assistant", "content": ""},
+    ])
+    sm = FakeSM({"s1": session})
+    text = asyncio.run(plugin._retry_empty_output(sm, "s1"))
+    assert text == "重试后的完整输出"
+    assert len(session.sent_messages) == 1
+
+
+def test_retry_empty_output_fails_after_all_attempts():
+    plugin = make_plugin()
+
+    class AlwaysEmptySession(FakeSession):
+        async def send_message(self, message, max_rounds=1, **kwargs):
+            self.sent_messages.append(message)
+            self.record.append(
+                {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+                 "content": ""}
+            )
+            return {"success": True}
+
+    session = AlwaysEmptySession([
+        {"id": "m1", "type": "assistant", "content": ""},
+    ])
+    sm = FakeSM({"s1": session})
+    text = asyncio.run(plugin._retry_empty_output(sm, "s1"))
+    assert text == ""
+    assert len(session.sent_messages) == plugin.EMPTY_OUTPUT_RETRY_COUNT
+
+
+def test_retry_empty_output_missing_session_returns_empty():
+    plugin = make_plugin()
+    assert asyncio.run(plugin._retry_empty_output(FakeSM({}), "ghost")) == ""

--- a/tests/test_agent_node_output_paths.py
+++ b/tests/test_agent_node_output_paths.py
@@ -1,0 +1,189 @@
+"""Agent 节点输出路径集成测试（空输出重试全覆盖）。
+
+覆盖评审要求：
+- require_non_empty_output + 最新为空但更早非空 → 重试成功
+- 仅 output_variable（无文件、无校验）→ 空输出重试 → outputs 写回
+- 文件 + 变量 → 重试结果写回 outputs[var] 与 _output_file
+- 重试 token 用量计入 NodeResult.token_usage
+- retry_empty_output=False 时空输出直接判失败
+- 重试全部失败 → failed，不返回更早的中间回复
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from src.workflow.nodes.agent import AgentNode
+
+
+class FakeSession:
+    """最小子会话桩：record + send_message + token 累计。"""
+
+    def __init__(self, record=None, retry_result="重试后的完整输出", token_step=100):
+        self.record = list(record or [])
+        self.retry_result = retry_result
+        self._token_calls = 0
+        self.token_step = token_step
+        self.sent_messages = []
+
+    async def send_message(self, message, max_rounds=1, **kwargs):
+        self.sent_messages.append(message)
+        self.record.append(
+            {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+             "content": self.retry_result}
+        )
+        return {"success": True}
+
+    def get_cumulative_token_usage(self):
+        # 每次读取 token 都会"增长"——用于验证重试后 token 重新读取
+        self._token_calls += 1
+        return {"model-x": {"total_tokens": 100 * self._token_calls,
+                            "prompt_tokens": 50 * self._token_calls,
+                            "completion_tokens": 50 * self._token_calls}}
+
+
+class FakeSM:
+    def __init__(self, session):
+        self.sessions = {session.session_id: session} if getattr(session, "session_id", None) else {"s1": session}
+        self.session = session
+
+    async def create_sub_session(self, **kwargs):
+        # 模拟子会话立即自动完成（graph 结束 → on_auto_complete）
+        on_auto_complete = kwargs.get("on_auto_complete")
+        if on_auto_complete:
+            on_auto_complete("s1", "子会话完成", "success", "")
+        return {"success": True, "session_id": "s1"}
+
+
+def _node(**overrides) -> SimpleNamespace:
+    fields = {
+        "id": "writer",
+        "agent_type": "agent_pp",
+        "system_prompt_template": "你是润色专家",
+        "first_message": "请完成润色任务",
+        "output_variable": "",
+        "save_output_to_file": False,
+        "output_file_path": "",
+        "require_non_empty_output": False,
+        "json_output_field": "",
+        "json_output_field_min_chars": 0,
+        "auto_flow": False,
+        "enable_complete_node_task": True,
+        "enable_reject_upstream": False,
+        "max_reject_count": 3,
+        "model_override": "",
+        "node_params": {},
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _ctx(node_def, shared_ws: str = "", sm=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        session_manager=sm,
+        node_def=node_def,
+        workflow_id="wf-test",
+        task_id="task-test",
+        parent_id="",
+        upstream_summary="",
+        on_reject_upstream=None,
+        needs_approval=False,
+        shared_ws=Path(shared_ws) if shared_ws else None,
+        definition=SimpleNamespace(variables={}),
+        parameter_values={},
+        node_state=SimpleNamespace(
+            session_id="", next_attempt_trigger="", summary="", status="", error="",
+        ),
+        checkpoint=None,
+    )
+
+
+async def _run(node_def, session, monkeypatch, shared_ws: str = ""):
+    from src.web.event_bus import event_bus
+
+    monkeypatch.setattr(event_bus, "emit_event", lambda *a, **k: None)
+    monkeypatch.setattr(event_bus, "emit_chat", lambda *a, **k: None)
+    sm = FakeSM(session)
+    ctx = _ctx(node_def, shared_ws, sm=sm)
+    return await AgentNode().execute(ctx)
+
+
+def test_require_non_empty_retries_when_latest_empty(monkeypatch):
+    """评审：require_non_empty_output 开启时，最新为空但更早非空 → 复用子会话重试。"""
+    node = _node(require_non_empty_output=True, output_variable="result")
+    session = FakeSession([
+        {"id": "m1", "type": "assistant", "content": "更早的中间回复"},
+        {"id": "m2", "type": "assistant", "content": ""},
+    ])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "completed"
+    assert result.outputs["result"] == "重试后的完整输出"
+    assert len(session.sent_messages) >= 1  # 确实发生了重试
+
+
+def test_output_variable_only_retries_empty(monkeypatch):
+    """评审：仅 output_variable（无文件、无校验）→ 空输出也走重试并写回。"""
+    node = _node(output_variable="result")
+    session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "completed"
+    assert result.outputs["result"] == "重试后的完整输出"
+
+
+def test_file_and_variable_retry_writes_back(monkeypatch):
+    """评审：文件 + 变量 → 重试结果写回 outputs[var] 与 _output_file。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        node = _node(
+            output_variable="result",
+            save_output_to_file=True,
+            output_file_path="out.txt",
+        )
+        session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+        result = asyncio.run(_run(node, session, monkeypatch, shared_ws=tmp))
+        assert result.status == "completed"
+        assert result.outputs["result"] == "重试后的完整输出"
+        assert "_output_file" in result.outputs
+        written = Path(result.outputs["_output_file"]).read_text(encoding="utf-8")
+        assert written == "重试后的完整输出"
+
+
+def test_retry_token_usage_accounted(monkeypatch):
+    """评审：重试消耗的模型调用必须计入 NodeResult.token_usage。"""
+    node = _node(output_variable="result")
+    session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "completed"
+    # 首次读取（100）→ 重试后重读（200），token_usage 应为重试后的值
+    assert result.token_usage == {"model-x": {
+        "total_tokens": 200, "prompt_tokens": 100, "completion_tokens": 100,
+    }}
+
+
+def test_retry_disabled_fails_on_empty(monkeypatch):
+    """评审：retry_empty_output=False 时，空输出直接判失败（显式控制重试）。"""
+    node = _node(
+        output_variable="result",
+        require_non_empty_output=True,
+        node_params={"retry_empty_output": False},
+    )
+    session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "failed"
+    assert "校验失败" in (result.error or "")
+
+
+def test_retry_all_fail_returns_failed_not_older_reply(monkeypatch):
+    """评审：重试全部失败 → failed，不得返回更早的中间回复。"""
+    node = _node(output_variable="result")
+    session = FakeSession(
+        [{"id": "m1", "type": "assistant", "content": "更早的中间回复"},
+         {"id": "m2", "type": "assistant", "content": ""}],
+        retry_result="",  # 重试也一直空
+    )
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "failed"
+    assert result.outputs.get("result") is None

--- a/tests/test_workflow_recovery_regressions.py
+++ b/tests/test_workflow_recovery_regressions.py
@@ -260,7 +260,7 @@ def test_agent_file_output_requires_a_final_ai_message(tmp_path):
     )
 
     assert result.status == "failed"
-    assert "没有最终 AI 输出" in result.error
+    assert ("LLM 输出为空" in result.error or "没有最终 AI 输出" in result.error)
     assert result.outputs == {}
     assert not (tmp_path / "result.json").exists()
 
@@ -312,7 +312,7 @@ def test_agent_output_gate_does_not_fall_back_to_older_non_empty_message(tmp_pat
     )
 
     assert result.status == "failed"
-    assert "LLM 最终输出为空" in result.error
+    assert "LLM 输出为空" in result.error
     assert result.outputs == {}
     assert not (tmp_path / "result.json").exists()
 


### PR DESCRIPTION
DeepSeek 推理模式偶发只输出 reasoning 而无正文，agent 节点拿到空输出
直接判失败，触发任务级恢复重跑整条管线（已完成节点被重复执行，实测
要 3 次才成功）。修复：空输出时复用同一子会话重试（最多 2 次），只重跑
当前节点；同时 _get_last_ai_message/_get_latest_ai_message 改用 message_content_text 统一转换，兼容 OpenAI 结构化 content（list 块）， 避免结构化格式被误判为空输出。

测试：tests/test_agent_empty_output_retry.py（7 项）。