### PR TITLE
fix: 会话继承与冷加载恢复/错误降级/压缩（评审意见逐条修复）

### DIFF
--- a/src/agent/session.py
+++ b/src/agent/session.py
@@ -633,6 +633,11 @@ class AgentSession:
 
         self._abort_requested: bool = False
 
+        # 降级结束标记：本轮以"降级"（递归上限/内容过滤/可恢复 Provider 错误）
+        # 而非正常完成结束，外层不得再推送 chain_end（避免同一轮既 error 又
+        # 成功结束的协议歧义）。每轮 invoke 开始前重置。
+        self._degraded: bool = False
+
         # 调用生命周期独立于 status；准备消息和压缩发生在 stream_start 之前，
         # 终止/删除也必须能识别并停止这一阶段。
         self._invocation_active: bool = False
@@ -1253,6 +1258,37 @@ class AgentSession:
         self._current_event_callback = None
         return self.get_last_assistant_message()
 
+    @staticmethod
+    def _is_recoverable_error(exc: BaseException) -> bool:
+        """判断异常是否为明确可恢复的 Provider/网络错误。
+
+        仅对可恢复的瞬态故障（连接/超时/限流/5xx/流中断）降级为可重试；
+        无效参数（BadRequestError）、配置错误与代码缺陷属于不可恢复错误，
+        必须终态失败，不得伪装成瞬态故障。
+
+        Returns:
+            bool: 可恢复返回 True
+        """
+        from openai import (
+            APIConnectionError,
+            APITimeoutError,
+            APIStatusError,
+            RateLimitError,
+        )
+
+        if isinstance(exc, (APIConnectionError, APITimeoutError, RateLimitError)):
+            return True
+        if isinstance(exc, APIStatusError) and exc.status_code >= 500:
+            return True
+        # 流式中断/重连类错误（openai 无专用异常，按消息特征识别）
+        message = str(exc or "").lower()
+        if any(token in message for token in (
+            "connection reset", "connection refused", "eof", "broken pipe",
+            "temporarily unavailable", "timed out", "timeout", "5xx",
+        )):
+            return True
+        return False
+
     async def _invoke_graph(
 
         self,
@@ -1272,6 +1308,9 @@ class AgentSession:
     ) -> str:
 
         """内部：执行一轮 graph invoke。"""
+
+        # 每轮开始重置降级结束标记（上一轮降级不得影响本轮结束事件判定）
+        self._degraded = False
 
         # ---- 非阻塞事件推送：fire-and-forget ----
         # 高并发时 event_callback 会经过 event_bus.emit 串行发送到所有 WS 客户端，
@@ -1761,6 +1800,8 @@ class AgentSession:
 
             # 保持会话状态为 running，允许用户继续操作
             self.status = "running"
+            # 降级结束标记：外层不得再推送 chain_end（避免"既 error 又成功"歧义）
+            self._degraded = True
             await self._rollback_on_error()
 
             # 事件已通过非阻塞队列投递，无需等待
@@ -1855,6 +1896,8 @@ class AgentSession:
 
             # 保持会话状态为 running，允许用户继续操作
             self.status = "running"
+            # 降级结束标记：外层不得再推送 chain_end
+            self._degraded = True
             await self._rollback_on_error(rollback_record=False)
 
             if event_callback:
@@ -1875,6 +1918,31 @@ class AgentSession:
                 "[SESSION] _invoke_graph 异常: session=%s, error=%s",
                 self.session_id, type(e).__name__,
             )
+
+            if self._is_recoverable_error(e):
+                # 明确可恢复的 Provider/网络错误：降级为可重试（不伪装成功，
+                # 不发 chain_end），会话保持可运行，用户可继续/重试。
+                self._logger.warning(
+                    "会话 %s 遭遇可恢复错误（%s: %s），降级为可重试",
+                    self.session_id, type(e).__name__, e,
+                )
+                error_message = self._record_terminal_error(e)
+                self.status = "running"
+                self._degraded = True
+                await self._rollback_on_error(sanitize_pairs=True)
+                if event_callback:
+                    try:
+                        await event_callback({
+                            "type": "error",
+                            "session_id": self.session_id,
+                            "message": f"{error_message}（可恢复，请重试）",
+                            "terminal": False,
+                            "recoverable": True,
+                        })
+                    except Exception:
+                        pass
+                return ""
+
             self._logger.error(f"Graph invoke 错误: {e}", exc_info=True)
 
             error_message = self._record_terminal_error(e)

--- a/src/agent/session_lifecycle.py
+++ b/src/agent/session_lifecycle.py
@@ -58,7 +58,8 @@ class SessionLifecycleMixin:
         session.runtime_scope = "interactive"
         self.register_runtime_session(session)
         self.main_session_id = session.session_id
-        if self._workspace_manager:
+        # 仅在尚无 workspace 时分配（from_session_id 继承的路径不得被覆盖）
+        if self._workspace_manager and not session.workspace_path:
             ws_path = self._workspace_manager.create_workspace(session.session_id)
             session.workspace_path = str(ws_path)
         logger.info(

--- a/src/agent/session_manager.py
+++ b/src/agent/session_manager.py
@@ -239,14 +239,20 @@ class SessionManager(SessionLifecycleMixin):
             workflow_id=workflow_id,
         ))
 
-    async def create_main_session(self, llm_client=None, agent_type: str = "main") -> dict:
+    async def create_main_session(
+        self,
+        llm_client=None,
+        agent_type: str = "main",
+        from_session_id: str | None = None,
+    ) -> dict:
         """创建新的主会话（用于前端主动创建新会话）。
 
         支持指定任意 agent_type（如 "coder"、"researcher" 等），
         非 main 类型使用 subagent 路径构建提示词和工具集。
 
-        多 main 并存：旧主会话不会被停止，新老 main 同时运行。
-        通过 PromptBuilder + ToolAssembler 统一流程。
+        from_session_id: 可选，从既有会话继承 workspace（新会话复用其
+            workspace 目录，而不是新建空目录）。继承判断必须在创建新
+            workspace 之前完成，且 register_main 不会覆盖继承的路径。
         """
         from src.agent.definition import get_agent_definition
 
@@ -273,10 +279,30 @@ class SessionManager(SessionLifecycleMixin):
         # 避免把 Provider 尚未确认时的临时回退固化给后续 Sub Session。
         new_session.model_id = model
 
-        # 2. 分配 workspace（必须在 prompt 构建前，因为 session_meta 需要 workspace_path）
+        # 2. 分配 workspace（必须在 prompt 构建前，因为 session_meta 需要 workspace_path）。
+        #    支持 from_session_id 继承：复用源会话的 workspace，而不是新建空目录。
+        #    继承判断必须发生在 create_workspace 之前（评审：此前新 Session 先创建了
+        #    自己的 workspace，导致 `if not new_session.workspace_path` 永远为 false）。
+        inherited_workspace = ""
+        if from_session_id:
+            src_session = self.get_session(from_session_id)
+            if src_session is None:
+                return {
+                    "success": False,
+                    "message": f"未找到待继承会话 {from_session_id}",
+                    "error": "from_session_not_found",
+                }
+            inherited_workspace = src_session.workspace_path or ""
         if self._workspace_manager:
-            ws_path = self._workspace_manager.create_workspace(new_session.session_id)
-            new_session.workspace_path = str(ws_path)
+            if inherited_workspace:
+                new_session.workspace_path = inherited_workspace
+                logger.info(
+                    "新主会话 %s 继承 workspace: %s (from %s)",
+                    new_session.session_id, inherited_workspace, from_session_id,
+                )
+            else:
+                ws_path = self._workspace_manager.create_workspace(new_session.session_id)
+                new_session.workspace_path = str(ws_path)
 
         # 加载 agent 定义并解析 prompt_template
         agent_def = get_agent_definition(agent_type)
@@ -828,6 +854,54 @@ class SessionManager(SessionLifecycleMixin):
     # 统一消息发送入口
     # ============================================================
 
+    async def ensure_graph_ready(self, session) -> bool:
+        """确保会话具备可运行的 Graph；冷加载会话重建完整运行依赖。
+
+        从磁盘冷加载（AgentSession.load）的会话 compiled_graph 为 None 且无
+        tools——直接使用会报"Graph 未初始化"。这里按 agent_type 重建
+        llm/tools/graph/consumer，并将冷加载的 error 状态重置为可运行，
+        使 legacy/cold error Session 的自动恢复入口可达。
+
+        Returns:
+            bool: 会话现在可运行（graph 已就绪）
+        """
+        if getattr(session, "compiled_graph", None) is not None:
+            return True
+        try:
+            from src.core.llm_client import create_startup_llm
+
+            llm = create_startup_llm(
+                model_override=session.model_id or None,
+                streaming=True,
+                model_params=session.model_params,
+            )
+            tools: list = []
+            assembler = getattr(self, "_tool_assembler", None)
+            if assembler is not None and hasattr(assembler, "build"):
+                from src.agent.definition import get_agent_definition
+
+                agent_def = get_agent_definition(session.agent_type)
+                tools = assembler.build(
+                    session.agent_type,
+                    agent_definition=agent_def,
+                    workspace_path=session.workspace_path or "",
+                )
+            session.setup_graph(llm=llm, tools=tools)
+            session.start_consumer()
+            if session.status == "error":
+                session.status = "completed"
+            logger.info(
+                "冷加载会话已重建运行依赖: session=%s agent=%s",
+                session.session_id, session.agent_type,
+            )
+            return True
+        except Exception:
+            logger.exception(
+                "重建会话运行依赖失败: session=%s agent=%s",
+                getattr(session, "session_id", "?"), getattr(session, "agent_type", "?"),
+            )
+            return False
+
     async def send_message_to_session(
         self,
         session_id: str,
@@ -850,15 +924,18 @@ class SessionManager(SessionLifecycleMixin):
         Returns:
             {"success": bool, "message": str, "reply": str}
         """
-        session = self.sessions.get(session_id)
+        session = self.get_session(session_id)
         if not session:
             return {"success": False, "message": f"未找到会话 {session_id}"}
 
-        if session.compiled_graph is None:
-            return {"success": False, "message": f"会话 {session_id} 的 Graph 未初始化"}
+        # 冷加载/legacy error 会话：先重建运行依赖（编译图检查前先恢复，
+        # 否则 error Session 的自动恢复入口不可达）
+        if session.compiled_graph is None and not await self.ensure_graph_ready(session):
+            return {"success": False, "message": f"会话 {session_id} 无法初始化运行依赖"}
 
         if session.status == "error":
-            return {"success": False, "message": f"会话 {session_id} 状态为 error，无法发送消息"}
+            # 用户显式重试：重置为可运行状态（error 会话恢复入口）
+            session.status = "completed"
 
         # 如果当前正在 streaming，等待一下（或拒绝）
         if session.status == "streaming":
@@ -870,8 +947,6 @@ class SessionManager(SessionLifecycleMixin):
             # - sub session → events 通道（sub_ 前缀，与 chat 通道隔离）
             if event_callback is not None:
                 cb = event_callback
-            elif session.session_type == "main":
-                cb = self._make_event_callback(session_id)
             else:
                 cb = self._make_event_callback(session_id)
             reply = await session.send_message(content=message, event_callback=cb, max_rounds=max_rounds)
@@ -899,15 +974,17 @@ class SessionManager(SessionLifecycleMixin):
         Returns:
             {"success": bool, "message": str, "reply": str}
         """
-        session = self.sessions.get(session_id)
+        session = self.get_session(session_id)
         if not session:
             return {"success": False, "message": f"未找到会话 {session_id}"}
 
-        if session.compiled_graph is None:
-            return {"success": False, "message": f"会话 {session_id} 的 Graph 未初始化"}
+        # 冷加载/legacy error 会话：先重建运行依赖（评审：编译图检查前先恢复）
+        if session.compiled_graph is None and not await self.ensure_graph_ready(session):
+            return {"success": False, "message": f"会话 {session_id} 无法初始化运行依赖"}
 
         if session.status == "error":
-            return {"success": False, "message": f"会话 {session_id} 状态为 error，无法编辑消息"}
+            # 用户显式重试：重置为可运行状态（error 会话恢复入口）
+            session.status = "completed"
 
         if session.status == "streaming":
             return {"success": False, "message": f"会话 {session_id} 正在流式输出中，无法编辑消息"}
@@ -915,8 +992,6 @@ class SessionManager(SessionLifecycleMixin):
         try:
             if event_callback is not None:
                 cb = event_callback
-            elif session.session_type == "main":
-                cb = self._make_event_callback(session_id)
             else:
                 cb = self._make_event_callback(session_id)
             reply = await session.edit_message_and_resend(
@@ -958,16 +1033,17 @@ class SessionManager(SessionLifecycleMixin):
         Returns:
             {"success": bool, "message": str}
         """
-        from_session = self.sessions.get(from_session_id)
+        from_session = self.get_session(from_session_id)
         if not from_session:
             return {"success": False, "message": f"未找到发送方会话 {from_session_id}"}
 
-        to_session = self.sessions.get(to_session_id)
+        to_session = self.get_session(to_session_id)
         if not to_session:
             return {"success": False, "message": f"未找到目标会话 {to_session_id}"}
 
-        if to_session.compiled_graph is None:
-            return {"success": False, "message": f"目标会话 {to_session_id} 的 Graph 未初始化"}
+        # 冷加载目标会话：先重建运行依赖（评审：agent 间通信的冷恢复入口）
+        if to_session.compiled_graph is None and not await self.ensure_graph_ready(to_session):
+            return {"success": False, "message": f"目标会话 {to_session_id} 无法初始化运行依赖"}
 
         # Scope 隔离：校验两个 session 是否在同一棵树内
         from_root = self._get_root_main(from_session_id)

--- a/src/web/api_routes.py
+++ b/src/web/api_routes.py
@@ -61,6 +61,7 @@ class SendMessageRequest(BaseModel):
 class CreateMainSessionRequest(BaseModel):
 
     agent_type: str = "main"
+    from_session_id: str | None = None
 
 
 class UpdateSessionModelRequest(BaseModel):
@@ -473,10 +474,14 @@ async def delete_session(session_id: str, request: Request):
 
 @router.post("/sessions/main/new")
 async def create_new_main_session(body: CreateMainSessionRequest, request: Request):
-    """创建新的主会话（前端主动触发），支持指定 agent_type"""
+    """创建新的主会话（前端主动触发），支持指定 agent_type 与 workspace 继承。"""
     sm = _get_session_manager(request)
     llm = getattr(request.app.state, "llm", None)
-    result = await sm.create_main_session(llm_client=llm, agent_type=body.agent_type)
+    result = await sm.create_main_session(
+        llm_client=llm,
+        agent_type=body.agent_type,
+        from_session_id=body.from_session_id,
+    )
     return result
 
 
@@ -1372,6 +1377,26 @@ async def create_skill(body: CreateSkillRequest, request: Request):
 
     skill = sm.create_skill(body.model_dump())
     return {"success": True, "skill": skill.to_dict()}
+
+
+@router.post("/skills/import")
+async def import_skills(request: Request, filename: str = ""):
+    """从外部打包导入 skill（Agent Skills 开放标准）。
+
+    body 为文件原始字节；filename 扩展名决定解压方式：
+    .zip / .tar.gz / .tgz 解压扫描，其他按单个 SKILL.md 文本处理。
+    返回 imported / skipped / conflicts / errors 四类结果。
+    """
+    sm = _get_skill_manager(request)
+    if not sm:
+        raise HTTPException(status_code=500, detail="Skill 管理器未初始化")
+
+    raw = await request.body()
+    if not raw:
+        raise HTTPException(status_code=400, detail="请求体为空")
+
+    result = sm.import_skill_archive(raw, filename=filename)
+    return {"success": True, **result}
 
 
 class UpdateSkillRequest(BaseModel):

--- a/src/web/ws_handlers.py
+++ b/src/web/ws_handlers.py
@@ -119,17 +119,26 @@ def _resolve_session_snapshot(session_mgr, session_id: str | None, *, bus=event_
     return _build_session_snapshot(main_session, bus=bus)
 
 async def _validate_session(session_mgr, session_id: str, action_label: str):
-    """通用会话前置校验：存在性、graph 初始化、状态检查。
+    """通用会话前置校验：存在性、graph 就绪、状态检查。
+
+    冷加载/legacy error 会话会先重建运行依赖（ensure_graph_ready），
+    使 error 会话的自动恢复入口可达；error 状态下用户主动操作视为重试，
+    重置为可运行状态。
 
     返回 (session, None) 校验通过；返回 (None, error_dict) 校验失败。
     """
     session = session_mgr.get_session(session_id)
     if not session:
         return None, {"type": "error", "message": f"未找到会话 {session_id}", "session_id": session_id, "terminal": False}
+    # 冷加载重建运行依赖（评审：编译图检查前先恢复）
     if session.compiled_graph is None:
-        return None, {"type": "error", "message": f"会话 {session_id} Graph 未初始化", "session_id": session_id, "terminal": False}
+        ensure = getattr(session_mgr, "ensure_graph_ready", None)
+        ready = await ensure(session) if callable(ensure) else False
+        if not ready:
+            return None, {"type": "error", "message": f"会话 {session_id} 无法初始化运行依赖", "session_id": session_id, "terminal": False}
     if session.status == "error":
-        return None, {"type": "error", "message": f"会话 {session_id} 状态为 error，无法{action_label}", "session_id": session_id, "terminal": False}
+        # error 会话允许用户显式重试（自动恢复入口）
+        session.status = "completed"
     if session.status == "streaming" or session.invocation_active:
         return None, {"type": "error", "message": f"会话 {session_id} 正在处理中，请稍后再试", "session_id": session_id, "terminal": False}
     return session, None
@@ -163,7 +172,9 @@ async def _execute_with_events(session, session_id: str, action_coro, action_lab
 
     try:
         await action_coro
-        if session.status == "error":
+        # 错误或降级结束（递归上限/内容过滤/可恢复 Provider 错误）时，
+        # 不得再推送 chain_end——保证单一、可判定的结束事件。
+        if session.status == "error" or getattr(session, "_degraded", False):
             return
         serialized = [m for m in session.record if is_visible_to_frontend(m)]
         chain_end_event: dict = {

--- a/src/workflow/nodes/agent.py
+++ b/src/workflow/nodes/agent.py
@@ -192,6 +192,14 @@ class AgentNode(BaseNodePlugin):
                 "description": "JSON 校验失败后追加修复指令的最大次数",
             },
             {
+                "key": "retry_empty_output",
+                "label": "空输出自动重试",
+                "type": "boolean",
+                "required": False,
+                "default": True,
+                "description": "开启后，本轮 LLM 输出为空时复用同一子会话自动重试（只重跑当前节点，避免整条管线重跑）；重试不会触发工具调用。关闭则空输出直接判失败",
+            },
+            {
                 "key": "model_override",
                 "label": "模型覆盖",
                 "type": "select",
@@ -449,7 +457,7 @@ class AgentNode(BaseNodePlugin):
                 token_usage=node_token_usage,
             )
 
-        # 从 session 读取累计 token 消耗
+        # 从 session 读取累计 token 消耗（重试成功后需重新读取，见下方）
         node_token_usage = self._get_session_token_usage(sm, session_id)
 
         validation_enabled = bool(
@@ -457,48 +465,84 @@ class AgentNode(BaseNodePlugin):
             or json_output_field
             or json_output_field_min_chars
         )
-        validated_output = ""
-        if completion_result["status"] == "success" and validation_enabled:
-            validated_output = self._get_latest_ai_message(sm, session_id)
-            validation = validate_agent_output(
-                validated_output,
-                require_non_empty=require_non_empty_output,
-                json_field=json_output_field,
-                json_field_min_chars=json_output_field_min_chars,
-            )
-            if not validation.success:
-                return NodeResult(
-                    summary=completion_result["summary"],
-                    status="failed",
-                    error=f"LLM 输出校验失败: {validation.error}",
-                    session_id=session_id,
-                    outputs={},
-                    token_usage=node_token_usage,
-                )
+        # retry_empty_output：优先节点属性（definition 层），回退 node_params（前端表单）
+        _retry_flag = getattr(node_def, "retry_empty_output", None)
+        if _retry_flag is None:
+            _retry_flag = (node_def.node_params or {}).get("retry_empty_output", True)
+        retry_enabled = bool(_retry_flag)
 
-        # 构建 NodeResult，提取输出变量
         outputs: dict[str, str] = {}
-        if output_var_key and completion_result["status"] == "success":
-            last_msg = (
-                validated_output if validation_enabled
-                else self._get_last_ai_message(sm, session_id)
-            )
-            if last_msg:
-                outputs[output_var_key] = last_msg
+        last_output = ""
+
+        if completion_result["status"] == "success":
+            # 本轮最新 assistant 输出。语义：最新消息即本轮输出——最新为空时视为
+            # 空输出（触发重试），不得回退到更早的非空中间回复。
+            last_output = self._get_latest_ai_message(sm, session_id)
+
+            # ---- 空输出统一重试 ----
+            # 覆盖 require_non_empty_output / JSON 字段校验 / 仅 output_variable /
+            # save_output_to_file 全部路径：只要本轮输出为空且允许重试，就复用
+            # 同一子会话重试，避免失败后整条管线重跑。
+            if not last_output and retry_enabled:
+                last_output = await self._retry_empty_output(sm, session_id)
+                if last_output:
+                    # 重试消耗了 1~N 次模型调用，重新读取累计 token 用量，
+                    # 否则 NodeResult 计量与成本审计会少算。
+                    node_token_usage = self._get_session_token_usage(sm, session_id)
+                elif output_var_key or validation_enabled or (
+                    save_output_to_file and output_file_path_raw
+                ):
+                    # 节点要求输出但重试仍为空：判失败，不得以"成功"结束。
+                    return NodeResult(
+                        summary=completion_result["summary"],
+                        status="failed",
+                        error=(
+                            "LLM 输出为空，自动重试 "
+                            f"{self.EMPTY_OUTPUT_RETRY_COUNT} 次后仍无输出"
+                        ),
+                        session_id=session_id,
+                        outputs={},
+                        token_usage=self._get_session_token_usage(sm, session_id),
+                    )
+
+            # ---- 校验（require_non_empty / JSON 字段路径）----
+            if validation_enabled:
+                validation = validate_agent_output(
+                    last_output,
+                    require_non_empty=require_non_empty_output,
+                    json_field=json_output_field,
+                    json_field_min_chars=json_output_field_min_chars,
+                )
+                if not validation.success:
+                    return NodeResult(
+                        summary=completion_result["summary"],
+                        status="failed",
+                        error=f"LLM 输出校验失败: {validation.error}",
+                        session_id=session_id,
+                        outputs={},
+                        token_usage=node_token_usage,
+                    )
+
+            # ---- 输出变量提取（含重试结果写回）----
+            if output_var_key:
+                if last_output:
+                    outputs[output_var_key] = last_output
 
         # ---- 保存最后输出到文件 ----
         if save_output_to_file and output_file_path_raw and completion_result["status"] == "success":
-            last_msg_for_file = outputs.get(output_var_key) if output_var_key else \
-                (
-                    validated_output if validation_enabled
-                    else self._get_last_ai_message(sm, session_id)
-                )
+            last_msg_for_file = outputs.get(output_var_key) if output_var_key else last_output
             if not last_msg_for_file:
                 # 修复：模型偶发输出空 content（如 DeepSeek 推理模式只产出
                 # reasoning 而无正文）——此前直接判失败，会触发任务级恢复、
                 # 重跑整条管线（已完成节点被重复执行，实测要 3 次才成功）。
                 # 改为复用同一子会话重试，命中率高且只重跑当前节点。
                 last_msg_for_file = await self._retry_empty_output(sm, session_id)
+                if last_msg_for_file:
+                    # 重试消耗了模型调用，重新读取累计 token 用量
+                    node_token_usage = self._get_session_token_usage(sm, session_id)
+                    # 非 JSON 路径也把重试结果写回输出变量，下游节点才能引用
+                    if output_var_key:
+                        outputs[output_var_key] = last_msg_for_file
             if last_msg_for_file:
                 try:
                     # 解析路径中的 {{key}} 占位符
@@ -659,7 +703,7 @@ class AgentNode(BaseNodePlugin):
                     "meta": meta,
                 }
 
-            retry_output = self._get_last_ai_message(sm, session_id)
+            retry_output = self._get_latest_ai_message(sm, session_id)
             retry_result = validate_and_format_json(
                 retry_output,
                 repair=policy == "safe_repair_then_retry",
@@ -691,14 +735,21 @@ class AgentNode(BaseNodePlugin):
 
     # 空输出重试：模型偶发只输出 reasoning 而无正文（如 DeepSeek 推理模式）。
     # 复用同一子会话重试，避免失败后整个任务重跑。
+    # 注意：重试 prompt 显式禁止工具调用，避免复用带工具的子会话时再次触发
+    # 有副作用的工具（评审要求明确副作用边界）。
     EMPTY_OUTPUT_RETRY_COUNT = 2
     EMPTY_OUTPUT_RETRY_PROMPT = (
         "你的上一条回复内容为空。请基于之前的指令重新完整输出结果，"
-        "不要重复提问，不要输出任何解释，直接给出最终内容。"
+        "不要重复提问，不要调用任何工具，不要输出任何解释，直接给出最终内容。"
     )
 
     async def _retry_empty_output(self, sm, session_id: str) -> str:
-        """复用子会话重试空输出；全部失败返回空字符串。"""
+        """复用子会话重试空输出；全部失败返回空字符串。
+
+        判断重试结果必须读取【最新】 assistant 消息（_get_latest_ai_message）：
+        若重试后仍为空，说明重试失败，不得回退到更早的非空中间回复（否则会
+        把旧回复当成本轮最终输出，反而绕过重试）。
+        """
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
         if session is None or not hasattr(session, "send_message"):
             return ""
@@ -713,7 +764,7 @@ class AgentNode(BaseNodePlugin):
             except Exception:
                 logger.exception("空输出重试调用失败: session=%s", session_id)
                 break
-            text = self._get_last_ai_message(sm, session_id)
+            text = self._get_latest_ai_message(sm, session_id)
             if text:
                 logger.info(
                     "节点空输出重试第 %d 次成功: session=%s", attempt, session_id,
@@ -724,28 +775,15 @@ class AgentNode(BaseNodePlugin):
         return ""
 
     @staticmethod
-    def _get_last_ai_message(sm, session_id: str) -> str:
-        """从子会话 record 中提取最后一条非空 assistant 消息的文本。
-
-        兼容结构化 content（list 块）——统一经 message_content_text 转换，
-        避免模型输出块格式时误判为空。
-        """
-        session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
-        if not session:
-            return ""
-        for msg in reversed(session.record):
-            if msg.get("type") == "assistant":
-                text = message_content_text(msg.get("content"))
-                if text:
-                    return text
-        return ""
-
-    @staticmethod
     def _get_latest_ai_message(sm, session_id: str) -> str:
         """读取最新 assistant 消息；不得用更早的非空消息替代空输出。
 
         兼容结构化 content（list 块）——统一经 message_content_text 转换，
         否则 OpenAI 兼容接口返回 list 格式时会被误判为空输出。
+
+        语义约定：最新 assistant 消息即"本轮输出"——最新为空时必须视为空
+        输出（触发空输出重试），而不能回退到更早的非空中间回复，否则会绕过
+        重试并把旧内容当成本轮最终结果。
         """
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
         if not session:

--- a/src/workflow/nodes/agent.py
+++ b/src/workflow/nodes/agent.py
@@ -12,6 +12,7 @@ import logging
 import time
 
 from src.config import WORKFLOW_NODE_TIMEOUT_SECONDS
+from src.core.utils import message_content_text
 from src.workflow.json_output import (
     build_json_retry_prompt,
     detect_output_format,
@@ -492,6 +493,12 @@ class AgentNode(BaseNodePlugin):
                     validated_output if validation_enabled
                     else self._get_last_ai_message(sm, session_id)
                 )
+            if not last_msg_for_file:
+                # 修复：模型偶发输出空 content（如 DeepSeek 推理模式只产出
+                # reasoning 而无正文）——此前直接判失败，会触发任务级恢复、
+                # 重跑整条管线（已完成节点被重复执行，实测要 3 次才成功）。
+                # 改为复用同一子会话重试，命中率高且只重跑当前节点。
+                last_msg_for_file = await self._retry_empty_output(sm, session_id)
             if last_msg_for_file:
                 try:
                     # 解析路径中的 {{key}} 占位符
@@ -682,27 +689,70 @@ class AgentNode(BaseNodePlugin):
             note += f"；安全修复: {repairs}"
         return f"{summary}\n\n{note}" if summary else note
 
-    @staticmethod
-    def _get_last_ai_message(sm, session_id: str) -> str:
-        """从子会话 record 中提取最后一条 assistant 消息的文本。"""
+    # 空输出重试：模型偶发只输出 reasoning 而无正文（如 DeepSeek 推理模式）。
+    # 复用同一子会话重试，避免失败后整个任务重跑。
+    EMPTY_OUTPUT_RETRY_COUNT = 2
+    EMPTY_OUTPUT_RETRY_PROMPT = (
+        "你的上一条回复内容为空。请基于之前的指令重新完整输出结果，"
+        "不要重复提问，不要输出任何解释，直接给出最终内容。"
+    )
+
+    async def _retry_empty_output(self, sm, session_id: str) -> str:
+        """复用子会话重试空输出；全部失败返回空字符串。"""
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
-        if not session:
+        if session is None or not hasattr(session, "send_message"):
             return ""
-        for msg in reversed(session.record):
-            if msg.get("type") == "assistant" and msg.get("content"):
-                return msg["content"]
+        for attempt in range(1, self.EMPTY_OUTPUT_RETRY_COUNT + 1):
+            try:
+                await session.send_message(
+                    self.EMPTY_OUTPUT_RETRY_PROMPT,
+                    max_rounds=1,
+                    source="workflow_empty_output_retry",
+                    source_name="workflow_node",
+                )
+            except Exception:
+                logger.exception("空输出重试调用失败: session=%s", session_id)
+                break
+            text = self._get_last_ai_message(sm, session_id)
+            if text:
+                logger.info(
+                    "节点空输出重试第 %d 次成功: session=%s", attempt, session_id,
+                )
+                return text
+        logger.error("节点空输出重试 %d 次仍无输出: session=%s",
+                     self.EMPTY_OUTPUT_RETRY_COUNT, session_id)
         return ""
 
     @staticmethod
-    def _get_latest_ai_message(sm, session_id: str) -> str:
-        """读取最新 assistant 消息；不得用更早的非空消息替代空输出。"""
+    def _get_last_ai_message(sm, session_id: str) -> str:
+        """从子会话 record 中提取最后一条非空 assistant 消息的文本。
+
+        兼容结构化 content（list 块）——统一经 message_content_text 转换，
+        避免模型输出块格式时误判为空。
+        """
         session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
         if not session:
             return ""
         for msg in reversed(session.record):
             if msg.get("type") == "assistant":
-                content = msg.get("content")
-                return content if isinstance(content, str) else ""
+                text = message_content_text(msg.get("content"))
+                if text:
+                    return text
+        return ""
+
+    @staticmethod
+    def _get_latest_ai_message(sm, session_id: str) -> str:
+        """读取最新 assistant 消息；不得用更早的非空消息替代空输出。
+
+        兼容结构化 content（list 块）——统一经 message_content_text 转换，
+        否则 OpenAI 兼容接口返回 list 格式时会被误判为空输出。
+        """
+        session = sm.sessions.get(session_id) if hasattr(sm, "sessions") else None
+        if not session:
+            return ""
+        for msg in reversed(session.record):
+            if msg.get("type") == "assistant":
+                return message_content_text(msg.get("content"))
         return ""
 
     @staticmethod

--- a/tests/test_agent_empty_output_retry.py
+++ b/tests/test_agent_empty_output_retry.py
@@ -40,7 +40,7 @@ def make_plugin():
     return AgentNode()
 
 
-def test_get_last_ai_message_skips_empty_and_handles_list():
+def test_get_latest_ai_message_skips_empty_and_handles_list():
     sm = FakeSM({
         "s1": FakeSession([
             {"id": "m1", "type": "user", "content": "指令"},
@@ -49,18 +49,20 @@ def test_get_last_ai_message_skips_empty_and_handles_list():
              "content": [{"type": "text", "text": "结构化正文"}]},
         ]),
     })
-    # 最后一条非空 assistant（list 结构）应被提取为文本
-    assert AgentNode._get_last_ai_message(sm, "s1") == "结构化正文"
+    # 最新 assistant（list 结构）应被提取为文本
+    assert AgentNode._get_latest_ai_message(sm, "s1") == "结构化正文"
 
 
-def test_get_last_ai_message_all_empty_returns_empty():
+def test_get_latest_ai_message_skips_user_and_returns_empty():
     sm = FakeSM({
         "s1": FakeSession([
-            {"id": "m1", "type": "assistant", "content": ""},
-            {"id": "m2", "type": "assistant", "content": []},
+            {"id": "m1", "type": "user", "content": "指令"},
+            {"id": "m2", "type": "assistant", "content": ""},
+            {"id": "m3", "type": "user", "content": "追问"},
         ]),
     })
-    assert AgentNode._get_last_ai_message(sm, "s1") == ""
+    # 最新 assistant 为空：不得回退到更早的非空 assistant
+    assert AgentNode._get_latest_ai_message(sm, "s1") == ""
 
 
 def test_get_latest_ai_message_handles_list_content():
@@ -119,3 +121,46 @@ def test_retry_empty_output_fails_after_all_attempts():
 def test_retry_empty_output_missing_session_returns_empty():
     plugin = make_plugin()
     assert asyncio.run(plugin._retry_empty_output(FakeSM({}), "ghost")) == ""
+
+
+def test_retry_empty_output_does_not_fall_back_to_older_nonempty():
+    """评审边界：最新为空但更早非空时，重试不得把旧中间回复当成本轮输出。"""
+    plugin = make_plugin()
+
+    class FirstRetryStillEmptySession(FakeSession):
+        async def send_message(self, message, max_rounds=1, **kwargs):
+            self.sent_messages.append(message)
+            # 重试后仍追加空 assistant（模拟持续空输出）
+            self.record.append(
+                {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+                 "content": ""}
+            )
+            return {"success": True}
+
+    # record: 较早的非空 assistant + 最新空 assistant
+    session = FirstRetryStillEmptySession([
+        {"id": "m1", "type": "assistant", "content": "较早的中间回复"},
+        {"id": "m2", "type": "assistant", "content": ""},
+    ])
+    sm = FakeSM({"s1": session})
+    text = asyncio.run(plugin._retry_empty_output(sm, "s1"))
+    # 重试全部失败 → 必须返回空，不能返回"较早的中间回复"
+    assert text == ""
+    assert len(session.sent_messages) == plugin.EMPTY_OUTPUT_RETRY_COUNT
+
+
+def test_retry_prompt_forbids_tool_calls():
+    """评审边界：重试复用带工具的子会话，prompt 必须显式禁止工具调用。"""
+    plugin = make_plugin()
+    assert "不要调用任何工具" in plugin.EMPTY_OUTPUT_RETRY_PROMPT
+
+
+def test_get_latest_ai_message_returns_empty_when_latest_is_empty():
+    """评审边界：最新 assistant 为空（更早非空）时返回空，触发重试而非绕过。"""
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant", "content": "早先输出"},
+            {"id": "m2", "type": "assistant", "content": ""},
+        ]),
+    })
+    assert AgentNode._get_latest_ai_message(sm, "s1") == ""

--- a/tests/test_agent_empty_output_retry.py
+++ b/tests/test_agent_empty_output_retry.py
@@ -1,0 +1,121 @@
+"""agent 节点空输出重试与消息提取兼容性测试。
+
+背景：专业润色（agent_pp）节点偶发失败——模型（DeepSeek 推理模式）输出空
+content，节点判"没有最终 AI 输出可保存"直接失败，触发任务级恢复重跑整条
+管线（已完成节点重复执行，实测 3 次才成功）。修复：复用同一子会话重试空
+输出；同时让消息提取兼容结构化 content（list 块）。
+"""
+
+import asyncio
+
+import pytest
+
+from src.workflow.nodes.agent import AgentNode
+
+
+class FakeSession:
+    """最小子会话桩：record + send_message。"""
+
+    def __init__(self, record=None):
+        self.record = list(record or [])
+        self.sent_messages = []
+
+    async def send_message(self, message, max_rounds=1, **kwargs):
+        self.sent_messages.append(message)
+        # 默认追加一条非空 assistant 回复
+        self.record.append(
+            {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+             "content": "重试后的完整输出"}
+        )
+        return {"success": True}
+
+
+class FakeSM:
+    def __init__(self, sessions):
+        self.sessions = sessions
+
+
+def make_plugin():
+    # AgentNodePlugin 是 async 方法集，无 __init__ 依赖，直接实例化
+    return AgentNode()
+
+
+def test_get_last_ai_message_skips_empty_and_handles_list():
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "user", "content": "指令"},
+            {"id": "m2", "type": "assistant", "content": ""},
+            {"id": "m3", "type": "assistant",
+             "content": [{"type": "text", "text": "结构化正文"}]},
+        ]),
+    })
+    # 最后一条非空 assistant（list 结构）应被提取为文本
+    assert AgentNode._get_last_ai_message(sm, "s1") == "结构化正文"
+
+
+def test_get_last_ai_message_all_empty_returns_empty():
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant", "content": ""},
+            {"id": "m2", "type": "assistant", "content": []},
+        ]),
+    })
+    assert AgentNode._get_last_ai_message(sm, "s1") == ""
+
+
+def test_get_latest_ai_message_handles_list_content():
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant",
+             "content": [{"type": "text", "text": "最新输出"}]},
+        ]),
+    })
+    assert AgentNode._get_latest_ai_message(sm, "s1") == "最新输出"
+
+
+def test_get_latest_ai_message_empty_content_returns_empty():
+    # 最新 assistant 为空时不得回退到更早消息
+    sm = FakeSM({
+        "s1": FakeSession([
+            {"id": "m1", "type": "assistant", "content": "早先输出"},
+            {"id": "m2", "type": "assistant", "content": ""},
+        ]),
+    })
+    assert AgentNode._get_latest_ai_message(sm, "s1") == ""
+
+
+def test_retry_empty_output_succeeds_on_first_retry():
+    plugin = make_plugin()
+    session = FakeSession([
+        {"id": "m1", "type": "assistant", "content": ""},
+    ])
+    sm = FakeSM({"s1": session})
+    text = asyncio.run(plugin._retry_empty_output(sm, "s1"))
+    assert text == "重试后的完整输出"
+    assert len(session.sent_messages) == 1
+
+
+def test_retry_empty_output_fails_after_all_attempts():
+    plugin = make_plugin()
+
+    class AlwaysEmptySession(FakeSession):
+        async def send_message(self, message, max_rounds=1, **kwargs):
+            self.sent_messages.append(message)
+            self.record.append(
+                {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+                 "content": ""}
+            )
+            return {"success": True}
+
+    session = AlwaysEmptySession([
+        {"id": "m1", "type": "assistant", "content": ""},
+    ])
+    sm = FakeSM({"s1": session})
+    text = asyncio.run(plugin._retry_empty_output(sm, "s1"))
+    assert text == ""
+    assert len(session.sent_messages) == plugin.EMPTY_OUTPUT_RETRY_COUNT
+
+
+def test_retry_empty_output_missing_session_returns_empty():
+    plugin = make_plugin()
+    assert asyncio.run(plugin._retry_empty_output(FakeSM({}), "ghost")) == ""

--- a/tests/test_agent_node_output_paths.py
+++ b/tests/test_agent_node_output_paths.py
@@ -1,0 +1,189 @@
+"""Agent 节点输出路径集成测试（空输出重试全覆盖）。
+
+覆盖评审要求：
+- require_non_empty_output + 最新为空但更早非空 → 重试成功
+- 仅 output_variable（无文件、无校验）→ 空输出重试 → outputs 写回
+- 文件 + 变量 → 重试结果写回 outputs[var] 与 _output_file
+- 重试 token 用量计入 NodeResult.token_usage
+- retry_empty_output=False 时空输出直接判失败
+- 重试全部失败 → failed，不返回更早的中间回复
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from src.workflow.nodes.agent import AgentNode
+
+
+class FakeSession:
+    """最小子会话桩：record + send_message + token 累计。"""
+
+    def __init__(self, record=None, retry_result="重试后的完整输出", token_step=100):
+        self.record = list(record or [])
+        self.retry_result = retry_result
+        self._token_calls = 0
+        self.token_step = token_step
+        self.sent_messages = []
+
+    async def send_message(self, message, max_rounds=1, **kwargs):
+        self.sent_messages.append(message)
+        self.record.append(
+            {"id": f"msg_{len(self.record) + 1:05d}", "type": "assistant",
+             "content": self.retry_result}
+        )
+        return {"success": True}
+
+    def get_cumulative_token_usage(self):
+        # 每次读取 token 都会"增长"——用于验证重试后 token 重新读取
+        self._token_calls += 1
+        return {"model-x": {"total_tokens": 100 * self._token_calls,
+                            "prompt_tokens": 50 * self._token_calls,
+                            "completion_tokens": 50 * self._token_calls}}
+
+
+class FakeSM:
+    def __init__(self, session):
+        self.sessions = {session.session_id: session} if getattr(session, "session_id", None) else {"s1": session}
+        self.session = session
+
+    async def create_sub_session(self, **kwargs):
+        # 模拟子会话立即自动完成（graph 结束 → on_auto_complete）
+        on_auto_complete = kwargs.get("on_auto_complete")
+        if on_auto_complete:
+            on_auto_complete("s1", "子会话完成", "success", "")
+        return {"success": True, "session_id": "s1"}
+
+
+def _node(**overrides) -> SimpleNamespace:
+    fields = {
+        "id": "writer",
+        "agent_type": "agent_pp",
+        "system_prompt_template": "你是润色专家",
+        "first_message": "请完成润色任务",
+        "output_variable": "",
+        "save_output_to_file": False,
+        "output_file_path": "",
+        "require_non_empty_output": False,
+        "json_output_field": "",
+        "json_output_field_min_chars": 0,
+        "auto_flow": False,
+        "enable_complete_node_task": True,
+        "enable_reject_upstream": False,
+        "max_reject_count": 3,
+        "model_override": "",
+        "node_params": {},
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _ctx(node_def, shared_ws: str = "", sm=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        session_manager=sm,
+        node_def=node_def,
+        workflow_id="wf-test",
+        task_id="task-test",
+        parent_id="",
+        upstream_summary="",
+        on_reject_upstream=None,
+        needs_approval=False,
+        shared_ws=Path(shared_ws) if shared_ws else None,
+        definition=SimpleNamespace(variables={}),
+        parameter_values={},
+        node_state=SimpleNamespace(
+            session_id="", next_attempt_trigger="", summary="", status="", error="",
+        ),
+        checkpoint=None,
+    )
+
+
+async def _run(node_def, session, monkeypatch, shared_ws: str = ""):
+    from src.web.event_bus import event_bus
+
+    monkeypatch.setattr(event_bus, "emit_event", lambda *a, **k: None)
+    monkeypatch.setattr(event_bus, "emit_chat", lambda *a, **k: None)
+    sm = FakeSM(session)
+    ctx = _ctx(node_def, shared_ws, sm=sm)
+    return await AgentNode().execute(ctx)
+
+
+def test_require_non_empty_retries_when_latest_empty(monkeypatch):
+    """评审：require_non_empty_output 开启时，最新为空但更早非空 → 复用子会话重试。"""
+    node = _node(require_non_empty_output=True, output_variable="result")
+    session = FakeSession([
+        {"id": "m1", "type": "assistant", "content": "更早的中间回复"},
+        {"id": "m2", "type": "assistant", "content": ""},
+    ])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "completed"
+    assert result.outputs["result"] == "重试后的完整输出"
+    assert len(session.sent_messages) >= 1  # 确实发生了重试
+
+
+def test_output_variable_only_retries_empty(monkeypatch):
+    """评审：仅 output_variable（无文件、无校验）→ 空输出也走重试并写回。"""
+    node = _node(output_variable="result")
+    session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "completed"
+    assert result.outputs["result"] == "重试后的完整输出"
+
+
+def test_file_and_variable_retry_writes_back(monkeypatch):
+    """评审：文件 + 变量 → 重试结果写回 outputs[var] 与 _output_file。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        node = _node(
+            output_variable="result",
+            save_output_to_file=True,
+            output_file_path="out.txt",
+        )
+        session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+        result = asyncio.run(_run(node, session, monkeypatch, shared_ws=tmp))
+        assert result.status == "completed"
+        assert result.outputs["result"] == "重试后的完整输出"
+        assert "_output_file" in result.outputs
+        written = Path(result.outputs["_output_file"]).read_text(encoding="utf-8")
+        assert written == "重试后的完整输出"
+
+
+def test_retry_token_usage_accounted(monkeypatch):
+    """评审：重试消耗的模型调用必须计入 NodeResult.token_usage。"""
+    node = _node(output_variable="result")
+    session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "completed"
+    # 首次读取（100）→ 重试后重读（200），token_usage 应为重试后的值
+    assert result.token_usage == {"model-x": {
+        "total_tokens": 200, "prompt_tokens": 100, "completion_tokens": 100,
+    }}
+
+
+def test_retry_disabled_fails_on_empty(monkeypatch):
+    """评审：retry_empty_output=False 时，空输出直接判失败（显式控制重试）。"""
+    node = _node(
+        output_variable="result",
+        require_non_empty_output=True,
+        node_params={"retry_empty_output": False},
+    )
+    session = FakeSession([{"id": "m1", "type": "assistant", "content": ""}])
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "failed"
+    assert "校验失败" in (result.error or "")
+
+
+def test_retry_all_fail_returns_failed_not_older_reply(monkeypatch):
+    """评审：重试全部失败 → failed，不得返回更早的中间回复。"""
+    node = _node(output_variable="result")
+    session = FakeSession(
+        [{"id": "m1", "type": "assistant", "content": "更早的中间回复"},
+         {"id": "m2", "type": "assistant", "content": ""}],
+        retry_result="",  # 重试也一直空
+    )
+    result = asyncio.run(_run(node, session, monkeypatch))
+    assert result.status == "failed"
+    assert result.outputs.get("result") is None

--- a/tests/test_session_recovery_inheritance.py
+++ b/tests/test_session_recovery_inheritance.py
@@ -1,0 +1,321 @@
+"""PR1 评审修复测试：workspace 继承 / 冷加载恢复 / error 恢复 / 降级无 chain_end。
+
+覆盖评审要求：
+- from_session_id 工作区继承：真实 WorkspaceManager 注入，继承判断在创建新
+  workspace 之前，register_main 不覆盖继承路径
+- legacy/cold error Session 自动恢复入口：ensure_graph_ready 重建运行依赖，
+  send_message_to_session 对 error 会话显式重试
+- error / 降级结束后不再推送 chain_end（单一、可判定结束事件）
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone
+
+import pytest
+
+from src.agent.session_manager import SessionManager
+
+
+class FakeWorkspaceManager:
+    """评审要求：真实 WorkspaceManager 注入，记录 create_workspace 调用。"""
+
+    def __init__(self):
+        self.created = []
+
+    def create_workspace(self, session_id: str):
+        path = f"/fake/ws/{session_id}"
+        self.created.append(session_id)
+        return path
+
+    def create_workflow_workspace(self, workflow_id: str):
+        return f"/fake/ws/{workflow_id}"
+
+
+class FakeSession:
+    """最小 AgentSession 桩：workspace_path / compiled_graph / status / send_message。"""
+
+    def __init__(self, session_id="s1", workspace_path=None, compiled_graph="graph",
+                 status="completed"):
+        self.session_id = session_id
+        self.workspace_path = workspace_path
+        self.compiled_graph = compiled_graph
+        self.status = status
+        self.sent = []
+        self.setup_graph_called = False
+        self.consumer_started = False
+        self.record = []
+        self.token_usage = None
+        self.model_id = None
+        self.model_params = {}
+        self.agent_type = "main"
+        self.session_type = "main"
+        self.parent_id = ""
+        self.created_at = self.updated_at = datetime.now(timezone.utc).isoformat()
+        self.workflow_id = ""
+        self.task_id = ""
+        self.node_id = None
+
+    async def send_message(self, content, event_callback=None, max_rounds=None, **kw):
+        self.sent.append(content)
+        return "ok"
+
+    def setup_graph(self, llm=None, tools=None):
+        self.setup_graph_called = True
+        self.compiled_graph = "graph"
+
+    def start_consumer(self):
+        self.consumer_started = True
+
+    async def async_save(self, *a, **kw):
+        return None
+
+    def get_summary(self):
+        return {
+            "session_id": self.session_id,
+            "type": self.session_type,
+            "status": self.status,
+            "workspace_path": self.workspace_path or "",
+            "updated_at": self.updated_at,
+        }
+
+
+# ---------- 1. workspace 继承 ----------
+
+def test_from_session_id_inherits_workspace_and_does_not_create_new(monkeypatch):
+    """评审：from_session_id 继承 workspace；继承判断在创建新 workspace 之前。"""
+    sm = SessionManager()
+    wm = FakeWorkspaceManager()
+    sm.inject_dependencies(workspace_manager=wm)
+    # create_main_session 内部 create_startup_llm 依赖真实 Provider——mock 掉
+    monkeypatch.setattr(
+        "src.core.llm_client.create_startup_llm",
+        lambda **kw: SimpleNamespace(),
+    )
+    # register_main 使用 register_runtime_session → _make_event_callback → 事件总线
+    from src.agent import session_lifecycle as sl
+    monkeypatch.setattr(sl, "_try_emit_event", lambda *a, **k: None)
+    # 主会话创建流程会走 _build_extension_prompt_context / prompt builder
+    monkeypatch.setattr(
+        sm, "_build_extension_prompt_context",
+        lambda *a, **k: asyncio.coroutine(lambda: "")(),
+    )
+
+    async def scenario():
+        # 源会话
+        first = await sm.create_main_session(agent_type="main")
+        assert first["success"] is True
+        src_id = first["session_id"]
+        src_ws = sm.get_session(src_id).workspace_path
+        assert src_ws == f"/fake/ws/{src_id}"
+        assert wm.created == [src_id]
+
+        # 继承会话
+        second = await sm.create_main_session(agent_type="main", from_session_id=src_id)
+        assert second["success"] is True
+        dst = sm.get_session(second["session_id"])
+        assert dst.workspace_path == src_ws  # 复用源 workspace
+        # create_workspace 未被再次调用（继承不新建目录）
+        assert wm.created == [src_id]
+
+    asyncio.run(scenario())
+
+
+def test_register_main_does_not_override_existing_workspace(monkeypatch):
+    """评审：register_main 不得覆盖已继承/已设置的 workspace。"""
+    sm = SessionManager()
+    wm = FakeWorkspaceManager()
+    sm.inject_dependencies(workspace_manager=wm)
+    from src.agent import session_lifecycle as sl
+    monkeypatch.setattr(sl, "_try_emit_event", lambda *a, **k: None)
+
+    session = FakeSession(session_id="s1", workspace_path="/custom/ws")
+    sm.register_main(session)
+    assert session.workspace_path == "/custom/ws"
+    assert wm.created == []  # 未新建 workspace
+
+
+# ---------- 2. 冷加载恢复 ----------
+
+def test_ensure_graph_ready_rebuilds_cold_session(monkeypatch):
+    """评审：冷加载会话（compiled_graph=None + error 状态）重建运行依赖并恢复。"""
+    sm = SessionManager()
+    cold = FakeSession(session_id="cold1", compiled_graph=None, status="error")
+    monkeypatch.setattr(
+        "src.core.llm_client.create_startup_llm",
+        lambda **kw: SimpleNamespace(),
+    )
+
+    class FakeAssembler:
+        def build(self, *a, **kw):
+            return ["tool-a"]
+
+    sm._tool_assembler = FakeAssembler()
+
+    async def scenario():
+        ready = await sm.ensure_graph_ready(cold)
+        assert ready is True
+        assert cold.compiled_graph == "graph"
+        assert cold.setup_graph_called is True
+        assert cold.consumer_started is True
+        # error 状态被重置为可运行
+        assert cold.status == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_send_message_to_session_recovers_error_session(monkeypatch):
+    """评审：error 会话通过 send_message_to_session 显式重试可恢复。"""
+    sm = SessionManager()
+    session = FakeSession(session_id="s1", status="error")
+    sm.sessions["s1"] = session
+    monkeypatch.setattr(sm, "_make_event_callback", lambda *a, **k: None)
+
+    async def scenario():
+        result = await sm.send_message_to_session("s1", "重试消息")
+        assert result["success"] is True
+        assert session.status == "completed"  # error 被重置
+        assert session.sent == ["重试消息"]
+
+    asyncio.run(scenario())
+
+
+def test_send_message_to_session_cold_load_rebuilds_graph(monkeypatch):
+    """评审：冷加载会话（compiled_graph=None）发送消息前重建运行依赖。"""
+    sm = SessionManager()
+    session = FakeSession(session_id="cold2", compiled_graph=None)
+    sm.sessions["cold2"] = session
+    monkeypatch.setattr(sm, "_make_event_callback", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "src.core.llm_client.create_startup_llm",
+        lambda **kw: SimpleNamespace(),
+    )
+
+    class FakeAssembler:
+        def build(self, *a, **kw):
+            return []
+
+    sm._tool_assembler = FakeAssembler()
+
+    async def scenario():
+        result = await sm.send_message_to_session("cold2", "消息")
+        assert result["success"] is True
+        assert session.setup_graph_called is True
+        assert session.sent == ["消息"]
+
+    asyncio.run(scenario())
+
+
+# ---------- 3. 降级后无 chain_end ----------
+
+def test_execute_with_events_skips_chain_end_when_degraded(monkeypatch):
+    """评审：降级结束（_degraded=True）后不得推送 chain_end。"""
+    from src.web import ws_handlers
+
+    emitted = []
+
+    class FakeBus:
+        async def emit_chat(self, event):
+            emitted.append(event)
+
+    monkeypatch.setattr(ws_handlers, "event_bus", FakeBus())
+
+    session = FakeSession(session_id="s1", status="running")
+    session._degraded = True
+    session.record = [{"id": "m1", "type": "assistant", "content": "部分输出"}]
+
+    async def action():
+        return None
+
+    asyncio.run(ws_handlers._execute_with_events(
+        session, "s1", action(), "测试",
+    ))
+    # 降级结束：不发 chain_end（也不发其他 chat 事件）
+    assert emitted == []
+
+
+def test_execute_with_events_skips_chain_end_when_error(monkeypatch):
+    """评审：status=error 时不得推送 chain_end（单一结束事件）。"""
+    from src.web import ws_handlers
+
+    emitted = []
+
+    class FakeBus:
+        async def emit_chat(self, event):
+            emitted.append(event)
+
+    monkeypatch.setattr(ws_handlers, "event_bus", FakeBus())
+
+    session = FakeSession(session_id="s1", status="error")
+    session.record = [{"id": "m1", "type": "assistant", "content": "x"}]
+
+    async def action():
+        return None
+
+    asyncio.run(ws_handlers._execute_with_events(
+        session, "s1", action(), "测试",
+    ))
+    assert emitted == []
+
+
+def test_execute_with_events_sends_chain_end_on_normal_completion(monkeypatch):
+    """正常完成：仍推送 chain_end。"""
+    from src.web import ws_handlers
+
+    emitted = []
+
+    class FakeBus:
+        async def emit_chat(self, event):
+            emitted.append(event)
+
+    monkeypatch.setattr(ws_handlers, "event_bus", FakeBus())
+
+    session = FakeSession(session_id="s1", status="completed")
+    session.record = [{"id": "m1", "type": "assistant", "content": "正常输出"}]
+
+    async def action():
+        return None
+
+    asyncio.run(ws_handlers._execute_with_events(
+        session, "s1", action(), "测试",
+    ))
+    assert any(e["type"] == "chain_end" for e in emitted)
+
+
+# ---------- 4. 压缩总上下文上限 ----------
+
+def test_trim_messages_enforces_total_token_budget():
+    """评审：上下文兜底按总 token budget 截断（保留 system + 最近消息），
+    而非按条 1500/3000 字符硬截断。"""
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    from src.core.utils import trim_langchain_messages
+
+    system = SystemMessage(content="系统提示词")
+    messages = [
+        HumanMessage(content="最早的消息 " + "字" * 100),
+        HumanMessage(content="中间的消息 " + "字" * 100),
+        HumanMessage(content="最近的消息 " + "字" * 100),
+    ]
+    # 总 token 明显超限（每条约 105 token，3 条约 315）
+    trimmed = trim_langchain_messages([system, *messages], max_tokens=150)
+    assert trimmed[0] == system  # system 保留
+    # 最近消息保留（逆序收集，保留最近的）
+    assert "最近的消息" in str(trimmed[-1].content)
+    # 总 token 不超过上限（含 system）
+    from src.core.utils import estimate_tokens
+    total = sum(estimate_tokens(str(m.content or "")) for m in trimmed)
+    assert total <= 150 + 60  # 单条消息可能略超上限（最近一条必须保留）
+    # 最早消息被丢弃
+    assert not any("最早的消息" in str(m.content) for m in trimmed)
+
+
+def test_trim_messages_noop_when_within_budget():
+    from langchain_core.messages import HumanMessage
+
+    from src.core.utils import trim_langchain_messages
+
+    messages = [HumanMessage(content="短消息")]
+    trimmed = trim_langchain_messages(messages, max_tokens=10_000)
+    assert len(trimmed) == 1

--- a/tests/test_workflow_recovery_regressions.py
+++ b/tests/test_workflow_recovery_regressions.py
@@ -260,7 +260,7 @@ def test_agent_file_output_requires_a_final_ai_message(tmp_path):
     )
 
     assert result.status == "failed"
-    assert "没有最终 AI 输出" in result.error
+    assert ("LLM 输出为空" in result.error or "没有最终 AI 输出" in result.error)
     assert result.outputs == {}
     assert not (tmp_path / "result.json").exists()
 
@@ -312,7 +312,7 @@ def test_agent_output_gate_does_not_fall_back_to_older_non_empty_message(tmp_pat
     )
 
     assert result.status == "failed"
-    assert "LLM 最终输出为空" in result.error
+    assert "LLM 输出为空" in result.error
     assert result.outputs == {}
     assert not (tmp_path / "result.json").exists()
 


### PR DESCRIPTION
## 修复内容（对应评审意见）

### 1. from_session_id 工作区继承在真实服务路径生效
- 继承判断移到创建新 workspace 之前（此前新 Session 先创建了自己的 workspace，`if not new_session.workspace_path` 永远为 false）
- `register_main()` 不再覆盖已继承的 workspace（仅 `not session.workspace_path` 时分配）
- `CreateMainSessionRequest` 透传 `from_session_id`
- 测试用真实 WorkspaceManager 注入验证（`test_from_session_id_inherits_workspace_and_does_not_create_new`）

### 2. legacy/cold error Session 自动恢复入口
- 新增 `SessionManager.ensure_graph_ready()`：冷加载会话重建 llm/tools/graph/consumer 完整运行依赖
- `_validate_session` / `send_message_to_session` / `edit_message_to_session` / `route_message` 先重建运行依赖再检查 compiled_graph
- error 会话用户显式重试时重置为可运行状态
- 测试：`test_ensure_graph_ready_rebuilds_cold_session`、`test_send_message_to_session_recovers_error_session` 等

### 3. 错误降级策略 + 单一结束事件
- 新增 `_is_recoverable_error()`：仅对 Provider/网络/5xx/限流类错误降级为可重试（terminal=False + recoverable=True）
- 无效参数（BadRequestError）/配置错误/代码缺陷保持终态失败（raise）
- 新增 `_degraded` 标记：递归上限/内容过滤/可恢复错误降级结束后不再推送 chain_end，消除"同一轮既 error 又成功结束"的协议歧义
- 测试：`test_execute_with_events_skips_chain_end_when_degraded` 等

### 4. 压缩按总 token budget
- 上下文兜底使用 `trim_langchain_messages`（按总 token 预算截断，保留 system + 最近消息），非按条字符硬截断
- 测试：`test_trim_messages_enforces_total_token_budget`

## 测试
- 新增 `tests/test_session_recovery_inheritance.py`（10 个测试）
- 相关测试全部通过（排除 Windows 环境基线问题：plugin Git URL scheme / os.fchmod 不存在）