### PR TITLE
fix(roundtable): close history persistence gaps and add history list entry

### DIFF
--- a/src/roundtable/runner.py
+++ b/src/roundtable/runner.py
@@ -357,6 +357,8 @@ class RoundtableRunner:
                     "round": controller.current_round,
                     "full_content": iv.content,
                 })
+                # 干预消息立即落盘，避免崩溃后丢失
+                session.save()
                 logger.info(f"Roundtable {session.session_id} 用户插话: {iv.content[:50]}")
 
             elif iv.intervention_type == "nominate":
@@ -386,6 +388,8 @@ class RoundtableRunner:
                             "round": controller.current_round,
                             "full_content": f"@{target.role_name} {iv.content}",
                         })
+                        # 干预消息立即落盘，避免崩溃后丢失
+                        session.save()
 
                     # 让指定 seat 发言
                     await event_bus.emit_chat({
@@ -1276,8 +1280,13 @@ class RoundtableManager:
         return self.sessions.get(session_id)
 
     def list_all(self) -> list[dict]:
-        """列出所有圆桌会议的摘要"""
-        return [s.get_summary() for s in self.sessions.values()]
+        """列出所有圆桌会议的摘要（按创建时间倒序，最新在前）"""
+        sessions = sorted(
+            self.sessions.values(),
+            key=lambda s: s.created_at,
+            reverse=True,
+        )
+        return [s.get_summary() for s in sessions]
 
     # ============ 持久化加载 ============
 

--- a/tests/test_roundtable_history.py
+++ b/tests/test_roundtable_history.py
@@ -1,0 +1,110 @@
+"""圆桌会议历史保存：干预消息即时落盘与历史列表排序"""
+import asyncio
+import json
+
+from src.roundtable.models import Intervention, RoundtableSession, Seat
+from src.roundtable.runner import RoundtableManager, RoundtableRunner
+from src.web.event_bus import event_bus
+
+
+def _session() -> RoundtableSession:
+    return RoundtableSession(
+        topic="历史保存测试",
+        seats=[
+            Seat(seat_id="seat-1", role_name="研究员", system_prompt="分析"),
+            Seat(seat_id="seat-2", role_name="评审", system_prompt="评审"),
+        ],
+    )
+
+
+def test_inject_intervention_is_persisted_immediately(monkeypatch, tmp_path) -> None:
+    """用户插话写入 transcript 后应立即落盘，进程崩溃也不丢失"""
+    monkeypatch.setattr("src.roundtable.models.SESSIONS_DIR", tmp_path)
+    emitted: list[dict] = []
+
+    async def capture(event: dict) -> None:
+        emitted.append(event)
+
+    monkeypatch.setattr(event_bus, "emit_chat", capture)
+
+    session = _session()
+    session.status = "discussing"
+    session.save()
+
+    async def scenario() -> bool:
+        await session.intervention_queue.put(
+            Intervention(intervention_type="inject", content="请记住这条插话")
+        )
+        return await RoundtableRunner()._process_interventions(session)
+
+    assert asyncio.run(scenario()) is False
+
+    # 直接从磁盘验证，不依赖内存状态
+    saved = json.loads(
+        (tmp_path / f"{session.session_id}.json").read_text(encoding="utf-8")
+    )
+    contents = [t["content"] for t in saved["transcript"]]
+    assert "请记住这条插话" in contents
+
+    # 回归：重新加载后插话仍在
+    restored = RoundtableSession.load(session.session_id)
+    assert restored is not None
+    assert any(t.content == "请记住这条插话" for t in restored.transcript)
+
+
+def test_nominate_with_content_is_persisted_immediately(monkeypatch, tmp_path) -> None:
+    """点名附带的用户消息写入 transcript 后应立即落盘"""
+    monkeypatch.setattr("src.roundtable.models.SESSIONS_DIR", tmp_path)
+
+    async def capture(event: dict) -> None:
+        pass
+
+    monkeypatch.setattr(event_bus, "emit_chat", capture)
+
+    # 避免真实 LLM 调用，只验证用户消息部分的落盘
+    async def fake_do_speak(self, seat, session, controller) -> None:
+        return None
+
+    monkeypatch.setattr(RoundtableRunner, "_do_speak", fake_do_speak)
+
+    session = _session()
+    session.status = "discussing"
+    session.save()
+
+    async def scenario() -> bool:
+        await session.intervention_queue.put(
+            Intervention(
+                intervention_type="nominate",
+                content="谈谈你的看法",
+                target_seat_id="seat-2",
+            )
+        )
+        return await RoundtableRunner()._process_interventions(session)
+
+    assert asyncio.run(scenario()) is False
+
+    saved = json.loads(
+        (tmp_path / f"{session.session_id}.json").read_text(encoding="utf-8")
+    )
+    contents = [t["content"] for t in saved["transcript"]]
+    assert "@评审 谈谈你的看法" in contents
+
+
+def test_list_all_returns_sessions_sorted_by_created_at_desc() -> None:
+    """历史会议列表按创建时间倒序，最新在前"""
+    manager = RoundtableManager()
+    older = _session()
+    older.created_at = "2026-08-01T00:00:00+00:00"
+    newer = _session()
+    newer.created_at = "2026-08-02T00:00:00+00:00"
+    middle = _session()
+    middle.created_at = "2026-08-01T12:00:00+00:00"
+    # 故意乱序插入，模拟内存字典顺序
+    manager.sessions = {s.session_id: s for s in (older, newer, middle)}
+
+    ordered = manager.list_all()
+    assert [s["created_at"] for s in ordered] == [
+        "2026-08-02T00:00:00+00:00",
+        "2026-08-01T12:00:00+00:00",
+        "2026-08-01T00:00:00+00:00",
+    ]

--- a/web/src/pages/RoundtablePage.tsx
+++ b/web/src/pages/RoundtablePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { Users, Play, Square, Plus, X, Zap, Brain, FileText, Pause, SkipForward, Send, UserPlus, CircleCheck, AlertTriangle, Search, Rocket, BarChart3, Loader2, RefreshCw } from "lucide-react";
+import { Users, Play, Square, Plus, X, Zap, Brain, FileText, Pause, SkipForward, Send, UserPlus, CircleCheck, AlertTriangle, Search, Rocket, BarChart3, Loader2, RefreshCw, ArrowLeft } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRoundtable } from "../hooks/useRoundtable";
 import TranscriptMessage from "../components/TranscriptMessage";
@@ -213,6 +213,15 @@ export default function RoundtablePage() {
         {/* 顶部状态栏 */}
         {activeSession && (
           <div className="px-6 py-3 border-b border-slate-700/50 bg-slate-800/80 flex items-center gap-4" role="banner" aria-label="会议状态栏">
+            <button
+              type="button"
+              onClick={clearActive}
+              aria-label="返回历史列表"
+              title="返回历史列表"
+              className="min-h-[44px] min-w-[44px] -ml-2 flex items-center justify-center rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500/30"
+            >
+              <ArrowLeft size={18} aria-hidden="true" />
+            </button>
             <Users size={18} className="text-cyan-500" aria-hidden="true" />
             <span className="text-sm font-medium text-slate-200 truncate flex-1">
               {activeSession.topic}


### PR DESCRIPTION
## 关联 Issue

Refs #15

## 问题

圆桌会议的历史保存链路有两个断点：

1. **干预消息不落盘**：`_process_interventions()` 中 inject（插话）和 nominate（点名附带消息）分支向 transcript 追加条目后没有 `session.save()`，而 pause/resume/add_seat/remove_seat 等其他干预分支都已有即时保存。进程在这两条消息之后、下一次发言落盘之前崩溃，用户消息丢失。
2. **无返回历史列表入口**：查看会议时（等待/讨论中/暂停），页面上没有任何返回历史列表的按钮，`clearActive` 只在会议结束后的"新建圆桌"中被调用，只能手动改 URL。

顺带修复：历史列表 `list_all()` 按内存字典序返回，改为按 `created_at` 倒序，最新会议在前。

## 改动

**后端 `src/roundtable/runner.py`**（+2 行核心逻辑）：
- inject 分支在广播事件后补 `session.save()`；
- nominate 分支在追加用户消息并广播后补 `session.save()`；
- `list_all()` 按 `created_at` 倒序返回。

**测试 `tests/test_roundtable_history.py`**（新增 3 个用例）：
- 插话处理后直接从磁盘 JSON 断言消息已落盘，并回归 `load()` 重载；
- 点名附带消息处理后磁盘断言（`_do_speak` 打桩避免 LLM 调用）；
- `list_all()` 倒序断言。

**前端 `web/src/pages/RoundtablePage.tsx`**（+10 行）：
- 顶部状态栏新增"返回历史列表"按钮（ArrowLeft），复用现有 `clearActive()`，遵循现有 44px 触控区与 focus-visible 样式约定。不改 hooks、类型或 API 层。

不改数据模型、不新增 API、不影响现有序列化格式。

## 验证

- `pytest tests/test_roundtable_history.py tests/test_roundtable_stream_recovery.py`：9 passed；
- 全量 `pytest -q`：与本机 main 基线逐项对比失败清单，**无新增失败**（本机 Windows 上 main 本身有 79 个失败，集中在 workflow executor / symlink 等环境相关用例；本机 `config/agents_config.json` 的本地改动另导致 4 个 model_manager 用例失败，与本 PR 无关，且 config 改动未包含在本 PR 中）；
- `cd web && npm run lint && npm run test:extensions && npm run test:workflow && npm run build`：全部通过（0 fail）；
- 集成冒烟（真实 FastAPI TestClient，临时 DATA_DIR）：创建两场会议 → 列表倒序 → 详情回放 → 磁盘文件存在 → 新进程 Manager `load_sessions()` 恢复 → 恢复后列表仍倒序，全链路通过。

本贡献按仓库 AGPL-3.0-only 许可证发布。