### PR TITLE
Fix frontend dependency installation on Windows

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,11 +2,14 @@
 
 Production uses the Gunicorn command declared by the Docker image.
 """
+import os
 import sys
 from pathlib import Path
 
 # 将项目根目录加入 sys.path
 sys.path.insert(0, str(Path(__file__).parent))
+
+npm_cmd = "npm.cmd" if os.name == "nt" else "npm"
 
 
 def _build_frontend_if_needed():
@@ -42,10 +45,10 @@ def _build_frontend_if_needed():
     # 检查 node_modules 是否存在
     if not (web_dir / "node_modules").exists():
         print("  📦 安装前端依赖...")
-        subprocess.run(["npm", "install"], cwd=str(web_dir), check=True)
+        subprocess.run([npm_cmd, "install"], cwd=str(web_dir), check=True)
 
     print("  🔨 前端源码有更新，正在构建...")
-    subprocess.run(["npm", "run", "build"], cwd=str(web_dir), check=True)
+    subprocess.run([npm_cmd, "run", "build"], cwd=str(web_dir), check=True)
     print("  ✅ 前端构建完成\n")
 
 
@@ -53,6 +56,7 @@ if __name__ == "__main__":
     import os
     import uvicorn
     from dotenv import load_dotenv
+
     load_dotenv()
 
     _build_frontend_if_needed()


### PR DESCRIPTION

Fix frontend startup failure on Windows.

Python `subprocess` may fail to locate `npm` on Windows because npm is exposed as `npm.cmd`.

This PR uses:

* `npm.cmd` on Windows
* `npm` on Linux/macOS


修复 Windows 环境下前端启动失败的问题。

由于 Windows 中 npm 实际通过 `npm.cmd` 执行，Python `subprocess` 直接调用 `npm` 时可能出现 `FileNotFoundError`。

本 PR 根据操作系统选择对应命令：

* Windows 使用 `npm.cmd`
* Linux/macOS 使用 `npm`
