### PR TITLE
fix(llm): recover from and root-fix empty/malformed LLM responses aborting sub-sessions

### DIFF
--- a/src/core/graph_builder.py
+++ b/src/core/graph_builder.py
@@ -19,6 +19,7 @@ from src.core.tool_guard import RoundsGuard, make_guarded_wrapper
 
 # 导入 llm_client 以确保 monkey patch 被应用（必须在使用 ChatOpenAI 之前）
 import src.core.llm_client  # noqa: F401
+from src.core.llm_client import LLMEmptyOrMalformedResponse
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +148,30 @@ def _make_llm_node(llm: BaseChatModel, tools: list[BaseTool]):
             try:
                 response = await llm_with_tools.ainvoke(request_messages)
                 break
+            except LLMEmptyOrMalformedResponse as exc:
+                # The LLM returned a chunk whose content is missing or shaped
+                # in a way LangChain cannot assemble into a BaseMessage. The
+                # call itself succeeded at the HTTP layer, so this is usually
+                # a transient truncation. Drop the oldest message round and
+                # retry once; if compaction cannot shrink further, escalate.
+                logger.warning(
+                    "[LLMEmptyOrMalformedResponse] attempting recovery | "
+                    "session_id=%s agent_type=%s retry=%s/%s",
+                    session_id,
+                    agent_type,
+                    retry_count + 1,
+                    max_retries,
+                )
+                if is_compressor or retry_count >= max_retries:
+                    raise
+                next_messages = reactive_strategy.discard_oldest_round(
+                    request_messages
+                )
+                if next_messages == request_messages:
+                    raise exc
+                retry_count += 1
+                request_messages = next_messages
+                continue
             except Exception as exc:
                 decision = checker.error_check(exc, request_messages)
                 if (

--- a/src/core/llm_client.py
+++ b/src/core/llm_client.py
@@ -12,12 +12,32 @@ from langchain_core.runnables.config import ensure_config, merge_configs
 from langchain_openai import ChatOpenAI
 from langchain_openai.chat_models import base as openai_base
 from openai import BadRequestError as OpenAIBadRequestError
+from pydantic import ValidationError
 
 import os
 import warnings
 
 logger = logging.getLogger(__name__)
 PROVIDER_BAD_REQUEST_ERRORS = (OpenAIBadRequestError, AnthropicBadRequestError)
+
+
+class LLMEmptyOrMalformedResponse(Exception):
+    """Wraps a LangChain/Provider ``ValidationError`` that fires when an
+    otherwise-successful HTTP response cannot be assembled into a
+    :class:`langchain_core.messages.BaseMessage`.
+
+    The reactive compact loop in :mod:`src.core.graph_builder` consumes this
+    exception to discard the oldest message round and retry, instead of
+    aborting the active sub-session on what is usually a transient upstream
+    truncation or content-filter quirk.
+    """
+
+    def __init__(self, original: BaseException) -> None:
+        super().__init__(
+            f"LLM returned a chunk LangChain could not validate: "
+            f"{type(original).__name__}: {original}"
+        )
+        self.original = original
 
 
 class ModelCredentialNotConfiguredError(ValueError):
@@ -376,6 +396,13 @@ def _wrap_llm_with_retry(llm: BaseChatModel, retry_config: dict) -> BaseChatMode
                 # 400 错误是永久性错误（输入格式非法），重试无意义，直接抛出
                 logger.error(f"LLM astream BadRequestError (400)，不重试")
                 raise
+            except ValidationError as validation_error:
+                # LangChain assembles each chunk into a BaseMessage at the
+                # boundary of astream. When the upstream response carries
+                # ``content=None``, the Pydantic model raises here even though
+                # the HTTP layer succeeded. Surface as a structured exception
+                # so the reactive compact loop can recover.
+                raise LLMEmptyOrMalformedResponse(validation_error) from validation_error
             except Exception as e:
                 last_error = e
                 # Once a chunk reached the consumer, restarting this request

--- a/src/core/llm_client.py
+++ b/src/core/llm_client.py
@@ -144,6 +144,33 @@ openai_base._convert_delta_to_message_chunk = _patched_convert_delta_to_message_
 
 
 # ============================================================
+# Monkey Patch 3: 消息解析 - 兼容非标准 role 下的 content=None
+# ============================================================
+
+_original_convert_dict_to_message = openai_base._convert_dict_to_message
+
+
+def _patched_convert_dict_to_message(_dict):
+    """
+    修补版本的消息解析函数，兼容 openai_compatible 中转站的 content=None
+
+    langchain-openai 的 _convert_dict_to_message 对 user/assistant/tool 等
+    标准 role 做了 content None 防护（assistant 分支为 `or ""`），但对未知
+    role 的 fallback 分支使用 `_dict.get("content", "")`——当上游返回
+    "content": null（键存在）时 get 返回 None 而非默认值，ChatMessage 随即
+    在 Pydantic 校验处抛出 "2 validation errors for ChatMessage"。
+    观测到的触发场景：DeepSeek V4 reasoning 响应经中转站返回非标准 role
+    且 content 为 null。此处统一把 null content 归一为空字符串。
+    """
+    if _dict.get("content") is None:
+        _dict = {**_dict, "content": ""}
+    return _original_convert_dict_to_message(_dict)
+
+
+openai_base._convert_dict_to_message = _patched_convert_dict_to_message
+
+
+# ============================================================
 # 应用补丁完成
 # ============================================================
 

--- a/tests/test_llm_client_validation_error.py
+++ b/tests/test_llm_client_validation_error.py
@@ -1,0 +1,111 @@
+"""Sub-session abort guard:
+
+When a LangChain ``BaseMessage`` cannot be assembled from a chunk (typical
+failure mode: ``content`` is ``None``), ``astream`` raises ``ValidationError``
+inside the provider adapter. The DeterminFlow retry wrapper should turn this
+into a known, recoverable :class:`LLMEmptyOrMalformedResponse` instead of
+letting the LangGraph subgraph abort the whole sub-session.
+
+These tests do not reach a real LLM; they substitute the wrapped object's
+``astream`` method with side-effecting callables and assert the wrapper
+surfaces them as the expected structured exception.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from src.core.llm_client import (
+    LLMEmptyOrMalformedResponse,
+    PROVIDER_BAD_REQUEST_ERRORS,
+    _wrap_llm_with_retry,
+)
+
+
+def _make_validation_error() -> ValidationError:
+    """Build a realistic Pydantic v2 ``ValidationError`` for
+    ``BaseMessage.content`` failing the ``str`` field validator."""
+    return ValidationError.from_exception_data(
+        title="BaseMessage",
+        line_errors=[
+            {
+                "type": "string_type",
+                "loc": ("content", "str"),
+                "input": None,
+                "msg": "Input should be a valid string",
+            }
+        ],
+    )
+
+
+def _llm_shell():
+    """A duck-typed object that the wrapper mutates in place via
+    ``object.__setattr__``. We do not need a real ``BaseChatModel`` because the
+    wrapper only ever reads / replaces ``ainvoke`` and ``astream`` on it."""
+    return SimpleNamespace(ainvoke=None, astream=None)
+
+
+def _drive(agen):
+    """Consume an async generator to completion, mirroring how the upstream
+    ``llm.astream(...)`` caller would invoke it from a sync test driver."""
+    async def _run():
+        async for _chunk in agen:
+            pass
+
+    return asyncio.run(_run())
+
+
+def test_astream_validation_error_is_wrapped() -> None:
+    inner = _make_validation_error()
+
+    async def _raise(_input, *_args, **_kwargs):
+        if False:  # pragma: no cover - shape marker for type checkers
+            yield None
+        raise inner
+
+    llm = SimpleNamespace(ainvoke=None, astream=_raise)
+    _wrap_llm_with_retry(llm, {"max_retries": 3, "delays": [0, 0, 0]})
+
+    with pytest.raises(LLMEmptyOrMalformedResponse) as excinfo:
+        _drive(llm.astream([]))
+
+    assert excinfo.value.original is inner
+    # ensure __cause__ is the original ValidationError so tracebacks stay useful
+    assert isinstance(excinfo.value.__cause__, ValidationError)
+
+
+def test_astream_provider_bad_request_skips_retry_path() -> None:
+    """A 400-class error from ``astream`` must surface as the original provider
+    exception and NOT be wrapped into ``LLMEmptyOrMalformedResponse``."""
+
+    class _DummyProviderBadRequest(Exception):
+        pass
+
+    bad_request = _DummyProviderBadRequest("simulated 400")
+
+    # Monkey-patch PROVIDER_BAD_REQUEST_ERRORS for this test only, then restore
+    # via try/finally. The wrapper uses this tuple to decide fast-path raises,
+    # so we must include our marker class for the assertion to be meaningful.
+    original = PROVIDER_BAD_REQUEST_ERRORS
+    import src.core.llm_client as llm_client_module
+
+    llm_client_module.PROVIDER_BAD_REQUEST_ERRORS = original + (_DummyProviderBadRequest,)
+    try:
+        llm = _llm_shell()
+        _wrap_llm_with_retry(llm, {"max_retries": 3, "delays": [0, 0, 0]})
+
+        async def _raise(_input, *_args, **_kwargs):
+            if False:  # pragma: no cover
+                yield None
+            raise bad_request
+
+        object.__setattr__(llm, "astream", _raise)
+
+        with pytest.raises(_DummyProviderBadRequest):
+            _drive(llm.astream([]))
+    finally:
+        llm_client_module.PROVIDER_BAD_REQUEST_ERRORS = original

--- a/tests/test_llm_client_validation_error.py
+++ b/tests/test_llm_client_validation_error.py
@@ -109,3 +109,31 @@ def test_astream_provider_bad_request_skips_retry_path() -> None:
             _drive(llm.astream([]))
     finally:
         llm_client_module.PROVIDER_BAD_REQUEST_ERRORS = original
+
+
+def test_convert_dict_to_message_coerces_null_content() -> None:
+    """Monkey Patch 3: a message dict with a non-standard ``role`` and
+    ``content: null`` must not crash ChatMessage validation.
+
+    langchain-openai's fallback branch uses ``_dict.get("content", "")`` which
+    returns ``None`` when the key exists with a null value. The DeterminFlow
+    patch coerces null content to "" before delegating.
+    """
+    from langchain_openai.chat_models import base as openai_base
+
+    # The patch is applied at llm_client import time; openai_base was already
+    # imported here so fetch the patched callable through the module attr.
+    import src.core.llm_client as llm_client_module  # noqa: F401
+
+    patched = openai_base._convert_dict_to_message
+
+    message = patched({"role": "custom_nonstandard_role", "content": None})
+    assert message.content == ""
+
+    # standard roles keep working through the original converter
+    assistant = patched({"role": "assistant", "content": None})
+    assert assistant.content == ""
+
+    # absent content key still defaults to ""
+    default = patched({"role": "custom_nonstandard_role"})
+    assert default.content == ""


### PR DESCRIPTION
## Summary

Sub-sessions abort on their first LLM call with `ERROR: Sub session ... 首条消息执行异常`. Production logs show **three distinct failure classes**; this PR addresses the two code-level ones (A and B below).

## Failure class A — `2 validation errors for ChatMessage` (root-fixed here)

Fast aborts (created → error within the same second), mostly `novel-director` / `novel-observer`.

Root cause in langchain-openai 1.3.3 (`chat_models/base.py`): the `assistant` branch guards null content (`_dict.get("content", "") or ""`), but the **fallback branch for unknown roles (line 264) does not**:

```python
return ChatMessage(content=_dict.get("content", ""), role=role, id=id_)
```

`_dict.get("content", "")` returns `None` (not the default `""`) when the key exists with a null value. An openai_compatible relay returning `"content": null` with a nonstandard role (observed with DeepSeek V4 reasoning responses) lands in this branch and `ChatMessage(content=None)` fails Pydantic validation.

**Fix (commit 2):** Monkey Patch 3 alongside the existing DeepSeek V4 patches in `src/core/llm_client.py` — wrap `openai_base._convert_dict_to_message` and coerce null content to `""` before delegating. Covers both `ainvoke` and `astream` at the source.

## Failure class B — reactive-loop recovery (safety net)

When a chunk still cannot be assembled (truncation, provider quirks), LangChain raises `pydantic_core.ValidationError` at the `BaseMessage` layer. The reactive compact loop did not recognize this as recoverable and aborted the subgraph.

**Fix (commit 1):** new `LLMEmptyOrMalformedResponse` wrapping the `ValidationError` inside `_wrap_llm_with_retry`'s `astream` wrapper, plus a dedicated recovery branch in `graph_builder.llm_node` that discards the oldest message round and retries, mirroring the existing reactive compact path.

## Failure class C — operational, not addressed in code

For completeness, production logs also show two config-side failures that need no code change:

- `LengthFinishReasonError` ("Could not parse response content as the length limit was reached"): `novel-character-maintainer` runs 13–18 min then exhausts the model's max output tokens. Mitigation: raise the model's output-token budget or split the node's task.
- `No streaming chunk received for 120.0s` (glm-5.2): tune `stream_chunk_timeout` (already forwarded from agent params) or `LANGCHAIN_OPENAI_STREAM_CHUNK_TIMEOUT_S`.

## What changed

- `src/core/llm_client.py`
  - New exception `LLMEmptyOrMalformedResponse` (commit 1).
  - `astream_with_retry` catches `ValidationError` and surfaces the structured exception (commit 1).
  - Monkey Patch 3: wrap `_convert_dict_to_message`, coerce null content to `""` (commit 2).
- `src/core/graph_builder.py`
  - Dedicated `except LLMEmptyOrMalformedResponse` recovery branch in the reactive compact loop (commit 1).
- `tests/test_llm_client_validation_error.py` (new)
  - astream `ValidationError` is wrapped; provider `BadRequestError` is not wrapped; `_convert_dict_to_message` coerces null content for nonstandard roles, standard roles, and absent keys.

## Verification

```
$ python -m pytest tests/test_llm_client_validation_error.py tests/test_llm_client_params.py tests/test_chat_stream_protocol.py tests/test_agent_output_recovery.py tests/test_workflow_node_retry_engine.py -q
78 passed
```

Zero regressions across the neighbouring LLM / stream / retry suites.

## License

By submitting this contribution I agree to release it under the AGPL-3.0 license of the upstream repository, as recorded in `CONTRIBUTING.md`.
