### PR TITLE
fix(desktop): recover fresh public login and rebuild v1.1.0

### DIFF
--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -43,6 +43,34 @@ jobs:
       - name: Verify latest official Plugin lock for Full candidate
         if: matrix.flavor == 'full' && github.ref_type != 'tag'
         run: python desktop/scripts/refresh_official_plugin_lock.py --check
+      - name: Resolve locked Plugin for native login regression
+        if: matrix.flavor == 'full'
+        id: plugin
+        shell: python
+        run: |
+          import json, os
+          from pathlib import Path
+          commit = json.loads(Path('desktop/official-plugins.lock.json').read_text())['source']['commit']
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+              output.write(f'commit={commit}\n')
+      - uses: actions/checkout@v4
+        if: matrix.flavor == 'full'
+        with:
+          repository: alikon-art/DeterminFlow-Plugins
+          ref: ${{ steps.plugin.outputs.commit }}
+          path: plugin-regression-source
+      - name: Test fresh account login on native platform
+        if: matrix.flavor == 'full'
+        shell: python
+        run: |
+          import os, sys
+          from pathlib import Path
+          import pytest
+          root = Path.cwd()
+          plugin = root / 'plugin-regression-source/plugins/public-api'
+          os.environ['DETERMINFLOW_CORE_ROOT'] = str(root)
+          sys.path[:0] = [str(plugin), str(root)]
+          sys.exit(pytest.main([str(plugin / 'tests/test_account_initialization.py'), '-q']))
       - name: Build web application
         working-directory: web
         run: npm ci && npm run build

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -76,6 +76,34 @@ jobs:
             tests/test_workflow_executor_pool_scenarios.py `
             tests/test_workflow_script_reject.py
 
+      - name: Resolve locked Plugin for native login regression
+        if: matrix.flavor == 'full'
+        id: plugin
+        shell: python
+        run: |
+          import json, os
+          from pathlib import Path
+          commit = json.loads(Path('desktop/official-plugins.lock.json').read_text())['source']['commit']
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+              output.write(f'commit={commit}\n')
+      - uses: actions/checkout@v4
+        if: matrix.flavor == 'full'
+        with:
+          repository: alikon-art/DeterminFlow-Plugins
+          ref: ${{ steps.plugin.outputs.commit }}
+          path: plugin-regression-source
+      - name: Test fresh account login on native platform
+        if: matrix.flavor == 'full'
+        shell: python
+        run: |
+          import os, sys
+          from pathlib import Path
+          import pytest
+          root = Path.cwd()
+          plugin = root / 'plugin-regression-source/plugins/public-api'
+          os.environ['DETERMINFLOW_CORE_ROOT'] = str(root)
+          sys.path[:0] = [str(plugin), str(root)]
+          sys.exit(pytest.main([str(plugin / 'tests/test_account_initialization.py'), '-q']))
       - name: Build web application
         working-directory: web
         run: |

--- a/.github/workflows/replace-desktop-assets.yml
+++ b/.github/workflows/replace-desktop-assets.yml
@@ -1,0 +1,129 @@
+name: Replace desktop release assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      windows_run:
+        description: Successful Windows build run from this exact commit
+        required: true
+      macos_run:
+        description: Successful macOS build run from this exact commit
+        required: true
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: replace-desktop-release-assets
+  cancel-in-progress: false
+
+jobs:
+  replace:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify exact build provenance and download artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WINDOWS_RUN: ${{ inputs.windows_run }}
+          MACOS_RUN: ${{ inputs.macos_run }}
+        run: |
+          mkdir -p release-assets
+          python - <<'PY'
+          import json, os, re, subprocess
+          from pathlib import Path
+          repo, sha = os.environ['GITHUB_REPOSITORY'], os.environ['GITHUB_SHA']
+          records = {}
+          for platform, key, workflow, artifacts in (
+              ('windows', 'WINDOWS_RUN', '.github/workflows/desktop-windows.yml',
+               ['DeterminFlow-Windows-x64-core', 'DeterminFlow-Windows-x64-full']),
+              ('macos', 'MACOS_RUN', '.github/workflows/desktop-macos.yml',
+               ['DeterminFlow-macOS-arm64-core-adhoc-candidate', 'DeterminFlow-macOS-arm64-full-adhoc-candidate']),
+          ):
+              run_id = os.environ[key]
+              if not re.fullmatch(r'[0-9]+', run_id):
+                  raise SystemExit('Invalid build run ID')
+              run = json.loads(subprocess.check_output(['gh', 'api', f'repos/{repo}/actions/runs/{run_id}']))
+              if (run['conclusion'] != 'success' or run['head_sha'] != sha
+                  or run['path'] != workflow or run['repository']['full_name'] != repo
+                  or run['event'] not in ('push', 'workflow_dispatch')):
+                  raise SystemExit(f'{platform}: build must be successful and match exact source/workflow')
+              for artifact in artifacts:
+                  subprocess.run(['gh', 'run', 'download', run_id, '--repo', repo,
+                                  '--name', artifact, '--dir', 'release-assets'], check=True)
+              records[platform] = run['html_url']
+          Path('build-runs.json').write_text(json.dumps(records))
+          PY
+      - name: Verify installers and prepare release metadata
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os, subprocess
+          from pathlib import Path
+          from desktop.scripts.create_update_manifest import create_manifest
+          assets = Path('release-assets')
+          version = json.loads(Path('desktop/src-tauri/tauri.conf.json').read_text())['version']
+          tag = f'v{version}'
+          subprocess.run(['gh', 'release', 'view', tag, '--repo', os.environ['GITHUB_REPOSITORY']], check=True)
+          expected = set()
+          for suffix in ('x64-setup.exe', 'x64-full-setup.exe', 'aarch64.dmg', 'aarch64-full.dmg'):
+              name = f'DeterminFlow_{version}_{suffix}'
+              expected.update((name, name + '.sha256'))
+              path = assets / name
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              parts = (assets / (name + '.sha256')).read_text().split()
+              if len(parts) != 2 or parts[0] != digest or parts[1].lstrip('*') != name:
+                  raise SystemExit(f'Checksum mismatch: {name}')
+              if suffix.endswith('.exe'):
+                  expected.add(name + '.sig')
+                  if not (assets / (name + '.sig')).read_text().strip():
+                      raise SystemExit(f'Missing updater signature: {name}')
+          if {p.name for p in assets.iterdir()} != expected:
+              raise SystemExit('Unexpected or missing release assets')
+          stamp = subprocess.check_output(['git', 'show', '-s', '--format=%cI', 'HEAD'], text=True).strip()
+          notes = Path(f'desktop/release-notes/{tag}.md').read_text()
+          manifest = create_manifest(version=version,
+              installer=assets / f'DeterminFlow_{version}_x64-setup.exe',
+              signature=assets / f'DeterminFlow_{version}_x64-setup.exe.sig',
+              base_url=f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}/releases/download/{tag}',
+              notes=notes, pub_date=stamp)
+          (assets / 'latest.json').write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + '\n')
+          provenance = {'version': version, 'source_commit': os.environ['GITHUB_SHA'],
+              'original_tag_commit': subprocess.check_output(['gh', 'api', f'repos/{os.environ["GITHUB_REPOSITORY"]}/commits/{tag}', '--jq', '.sha'], text=True).strip(),
+              'build_runs': json.loads(Path('build-runs.json').read_text()),
+              'plugins': json.loads(Path('desktop/official-plugins.lock.json').read_text()),
+              'sha256': {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in assets.iterdir()}}
+          (assets / 'build-source.json').write_text(json.dumps(provenance, indent=2) + '\n')
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'version={version}\ntag={tag}\npub_date={stamp}\n')
+          PY
+      - name: Replace GitHub assets and release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+          gh release edit "$RELEASE_TAG" --notes-file "desktop/release-notes/$RELEASE_TAG.md" --repo "$GITHUB_REPOSITORY"
+      - name: Publish rebuild to R2 and switch stable manifest
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_BUCKET: ${{ vars.R2_BUCKET }}
+          R2_ENDPOINT_URL: ${{ vars.R2_ENDPOINT_URL }}
+          VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          PUB_DATE: ${{ steps.release.outputs.pub_date }}
+        run: |
+          python desktop/scripts/publish_r2_release.py \
+            --assets-dir release-assets --version "$VERSION" --revision "$GITHUB_SHA" \
+            --notes-file "desktop/release-notes/$RELEASE_TAG.md" --pub-date "$PUB_DATE" \
+            --bucket "$R2_BUCKET" --endpoint-url "$R2_ENDPOINT_URL" \
+            --public-base-url "https://downloads.determinflow.com"

--- a/desktop/official-plugins.lock.json
+++ b/desktop/official-plugins.lock.json
@@ -9,12 +9,12 @@
     {
       "id": "public-api",
       "subdirectory": "plugins/public-api",
-      "version": "0.1.36"
+      "version": "0.1.37"
     }
   ],
   "schema_version": 1,
   "source": {
-    "commit": "5f074b5a887a7e74a61d00206abb99c107b786c2",
+    "commit": "e69aa37b752d22af711b9b7e5c371c9db018766b",
     "id": "determinflow-official",
     "ref": "main",
     "url": "https://github.com/alikon-art/DeterminFlow-Plugins.git"

--- a/desktop/release-notes/v1.1.0.md
+++ b/desktop/release-notes/v1.1.0.md
@@ -26,10 +26,17 @@
 | Windows x64 | `DeterminFlow_1.1.0_x64-setup.exe` | `DeterminFlow_1.1.0_x64-full-setup.exe` |
 | macOS Apple Silicon | `DeterminFlow_1.1.0_aarch64.dmg` | `DeterminFlow_1.1.0_aarch64-full.dmg` |
 
-Core 不捆绑插件。Full 内置 `bishu-novel 0.2.2`、`public-api 0.1.36`。
+Core 不捆绑插件。Full 内置 `bishu-novel 0.2.2`、`public-api 0.1.37`。
 升级保留已有用户数据和插件；Full 不覆盖已安装插件，请在插件页检查更新并重启。
 
 macOS 安装包尚未经过 Apple 公证。首次打开若被系统阻止，请在“系统设置 → 隐私与安全性”中
 选择“仍要打开”并确认。当前不提供 macOS 自动更新，请下载安装包手动升级。
 
 [官网与加速下载](https://determinflow.com/download) · [完整变更](https://github.com/alikon-art/DeterminFlow/compare/v1.0.10...v1.1.0)
+
+## 安装包修订：首次登录修复
+
+- 修复全新安装在引导页直接登录后，公益模型列表为空的问题。
+- 模型未就绪时显示实际失败原因和重试入口，避免误报模型列表已更新。
+- Full 内置公益插件升级为 `0.1.37`。已有用户请在插件页更新公益插件并重启；重新安装 Full 会保留已安装插件。
+- 本次保留 `1.1.0` 版本号并替换安装包，已安装用户需手动重新下载。原 `v1.1.0` Git 标签保留，修订包的精确源码提交、构建任务与文件摘要见附件 `build-source.json`。

--- a/desktop/scripts/publish_r2_release.py
+++ b/desktop/scripts/publish_r2_release.py
@@ -147,6 +147,7 @@ def publish_release(
     notes_file: Path,
     pub_date: str,
     publisher: R2Publisher,
+    revision: str | None = None,
 ) -> None:
     if not SEMVER_PATTERN.fullmatch(version):
         raise ValueError(f"invalid release version: {version}")
@@ -156,6 +157,10 @@ def publish_release(
         raise FileNotFoundError("Core installer or updater signature is missing")
 
     version_prefix = f"desktop/releases/v{version}"
+    if revision is not None:
+        if not re.fullmatch(r"[0-9a-f]{40}", revision):
+            raise ValueError("rebuild revision must be a full Git commit SHA")
+        version_prefix += f"/rebuilds/{revision}"
     assets = sorted(
         path
         for path in assets_dir.iterdir()
@@ -190,6 +195,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--assets-dir", type=Path, required=True)
     parser.add_argument("--version", required=True)
+    parser.add_argument("--revision", help="Publish a same-version rebuild without overwriting immutable assets")
     parser.add_argument("--notes-file", type=Path, required=True)
     parser.add_argument("--pub-date", required=True)
     parser.add_argument("--bucket", required=True)
@@ -201,6 +207,7 @@ def main() -> int:
     publish_release(
         assets_dir=options.assets_dir.resolve(),
         version=options.version,
+        revision=options.revision,
         notes_file=options.notes_file.resolve(),
         pub_date=options.pub_date,
         publisher=R2Publisher(

--- a/tests/test_desktop_packaging.py
+++ b/tests/test_desktop_packaging.py
@@ -627,7 +627,8 @@ def test_r2_publisher_rejects_changed_immutable_objects(tmp_path: Path) -> None:
         publisher.publish_immutable(asset, "desktop/releases/v1.2.3/asset.exe")
 
 
-def test_r2_release_publishes_latest_only_after_verified_assets(tmp_path: Path) -> None:
+@pytest.mark.parametrize("revision", [None, "a" * 40])
+def test_r2_release_publishes_latest_only_after_verified_assets(tmp_path: Path, revision: str | None) -> None:
     assets = tmp_path / "assets"
     assets.mkdir()
     installer = assets / "DeterminFlow_1.2.3_x64-setup.exe"
@@ -655,6 +656,7 @@ def test_r2_release_publishes_latest_only_after_verified_assets(tmp_path: Path) 
         notes_file=notes,
         pub_date="2026-08-29T00:00:00Z",
         publisher=RecordingPublisher(),  # type: ignore[arg-type]
+        revision=revision,
     )
 
     assert {key.rsplit("/", 1)[-1] for _, key, _ in calls} >= {
@@ -666,6 +668,9 @@ def test_r2_release_publishes_latest_only_after_verified_assets(tmp_path: Path) 
     assert json.loads(calls[-1][2])["platforms"]["windows-x86_64"][
         "url"
     ].startswith("https://downloads.determinflow.com/desktop/releases/v1.2.3/")
+    prefix = "desktop/releases/v1.2.3" + (f"/rebuilds/{revision}" if revision else "")
+    assert all(key.startswith(prefix + "/") for _, key, _ in calls[:-1])
+    assert f"/{prefix}/" in json.loads(calls[-1][2])["platforms"]["windows-x86_64"]["url"]
     assert IMMUTABLE_CACHE_CONTROL.endswith("immutable")
     assert LATEST_CACHE_CONTROL.startswith("no-cache")
 

--- a/web/src/components/onboarding/FirstRunModelScreen.tsx
+++ b/web/src/components/onboarding/FirstRunModelScreen.tsx
@@ -39,6 +39,7 @@ import {
   chooseInitialProviderId,
   findManagedModelExtension,
   managedModelChoices,
+  managedModelError,
   type ManagedModelStatus,
   normalizeApiError,
   parseManagedModelStatus,
@@ -187,21 +188,25 @@ export function FirstRunModelScreen({
   const publicModels = managedModelChoices(managedStatus);
   const publicReady = Boolean(
     managedStatus?.serviceEnabled
+      && !managedModelError(managedStatus)
       && (!managedStatus.signedIn || (
         managedStatus.providerId
         && managedStatus.models.length > 0
       )),
   );
 
-  const loadManagedStatus = useCallback(async (showLoading = true) => {
-    const endpoint = managedExtension?.header_status?.endpoint;
+  const loadManagedStatus = useCallback(async (showLoading = true, renew = false) => {
+    const endpoint = renew
+      ? managedExtension?.header_status?.refresh_endpoint
+      : managedExtension?.header_status?.endpoint;
     if (!endpoint) return;
     if (showLoading) setManagedLoading(true);
     try {
-      const status = await requestManagedModelStatus(endpoint);
+      const status = await requestManagedModelStatus(endpoint, renew ? "POST" : "GET");
       setManagedStatus(status);
-      setError(status.serviceEnabled ? "" : "公益模型服务暂时不可用");
+      setError(managedModelError(status));
     } catch (reason) {
+      setManagedStatus(null);
       setError(normalizeApiError(reason, "公益模型服务暂时无法连接"));
     } finally {
       if (showLoading) setManagedLoading(false);
@@ -455,7 +460,21 @@ export function FirstRunModelScreen({
                 </select>
               </div>
               <div className="first-run-public-model-summary">
-                {managedStatus?.signedIn ? (
+                {managedLoading || loginBusy ? (
+                  <strong>正在更新模型列表…</strong>
+                ) : error ? (
+                  <>
+                    <strong>公益模型暂不可用</strong>
+                    <button
+                      type="button"
+                      className="first-run-public-login"
+                      onClick={() => void loadManagedStatus(true, true)}
+                    >
+                      <RefreshCw size={15} aria-hidden="true" />
+                      重试
+                    </button>
+                  </>
+                ) : managedStatus?.signedIn ? (
                   <>
                     <strong>{publicModels.length} 个模型可用</strong>
                     <small>登录成功，模型列表已更新</small>

--- a/web/src/components/onboarding/firstRunOnboardingModel.test.ts
+++ b/web/src/components/onboarding/firstRunOnboardingModel.test.ts
@@ -15,6 +15,7 @@ import {
   getPluginChanges,
   normalizeApiError,
   parseManagedModelStatus,
+  managedModelError,
   requiresPluginRiskConfirmation,
   shouldConfirmManagedModelSelection,
   shouldStartFirstRun,
@@ -183,6 +184,8 @@ test("managed model status keeps dynamic copy while allowing an anonymous empty 
     },
   }), {
     serviceEnabled: true,
+    state: "unavailable",
+    lastError: null,
     signedIn: false,
     loginPending: false,
     loginEnabled: true,
@@ -260,4 +263,23 @@ test("anonymous onboarding follows service catalog and defaults to auto before a
   assert.deepEqual(managedModelChoices(status), ["auto"]);
   assert.deepEqual(managedModelChoices({ ...status, models: ["new-server-model"] }), ["new-server-model"]);
   assert.deepEqual(managedModelChoices({ ...status, signedIn: true, models: [] }), []);
+});
+
+
+test("account login is not model readiness and preserves recoverable errors", () => {
+  const parse = (fields: Record<string, unknown>) => parseManagedModelStatus({
+    signed_in: true, login_pending: false, state: "active",
+    provider_id: "public", models: ["model-a"],
+    login_endpoint: "/api/public-api/login",
+    ui: { service_enabled: true, login_enabled: true,
+      provider_display_name: "公益模型", service_notice: "说明" },
+    ...fields,
+  })!;
+  assert.equal(managedModelError(parse({})), "");
+  assert.ok(managedModelError(parse({ models: [] })));
+  assert.ok(managedModelError(parse({ provider_id: null })));
+  assert.ok(managedModelError(parse({ state: "expired" })));
+  assert.equal(managedModelError(parse({ last_error: "模型目录暂时无法读取" })), "模型目录暂时无法读取");
+  // Signed-out users can choose anonymous use before a credential exists.
+  assert.equal(managedModelError(parse({ signed_in: false, models: [], provider_id: null, state: "unavailable" })), "");
 });

--- a/web/src/components/onboarding/firstRunOnboardingModel.ts
+++ b/web/src/components/onboarding/firstRunOnboardingModel.ts
@@ -24,6 +24,8 @@ export interface PluginChange {
 
 export interface ManagedModelStatus {
   serviceEnabled: boolean;
+  state: string | null;
+  lastError: string | null;
   signedIn: boolean;
   loginPending: boolean;
   loginEnabled: boolean;
@@ -162,6 +164,8 @@ export function parseManagedModelStatus(
 
   return {
     serviceEnabled: ui.service_enabled,
+    state: typeof body.state === "string" ? body.state : null,
+    lastError: typeof body.last_error === "string" ? body.last_error.trim() || null : null,
     signedIn: body.signed_in,
     loginPending: body.login_pending,
     loginEnabled: ui.login_enabled,
@@ -235,4 +239,14 @@ export function normalizeApiError(reason: unknown, fallback: string): string {
 export function managedModelChoices(status: ManagedModelStatus | null): string[] {
   if (status?.models.length) return status.models;
   return status?.signedIn ? [] : ["auto"];
+}
+
+export function managedModelError(status: ManagedModelStatus): string {
+  if (!status.serviceEnabled) return status.lastError || "公益模型服务暂时不可用";
+  if (status.lastError) return status.lastError;
+  if (status.signedIn && (
+    !status.providerId || !status.models.length
+    || (status.state !== null && status.state !== "active")
+  )) return "账号已登录，但公益模型尚未就绪，请重试";
+  return "";
 }


### PR DESCRIPTION
Fresh account login now reports actual public-model readiness with a retry action, and Full bundles public-api 0.1.37. Native Windows/macOS builds run the missing fresh-login regression. Adds a manually dispatched replacement workflow that verifies successful builds from the exact source commit, records provenance, and publishes same-version rebuilds under a new immutable R2 path without moving the original Git tag. Validation: onboarding and design tests, frontend lint/build, and desktop packaging tests passed.