### PR TITLE
docs(release): align Full plugin version with rebuilt installers

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -218,7 +218,7 @@ Node.js, and Git are not required to start the desktop app.
 | Windows x64 | `DeterminFlow_1.1.0_x64-setup.exe` | `DeterminFlow_1.1.0_x64-full-setup.exe` |
 | macOS Apple Silicon | `DeterminFlow_1.1.0_aarch64.dmg` | `DeterminFlow_1.1.0_aarch64-full.dmg` |
 
-Core bundles no plugins. Full includes `bishu-novel 0.2.2` and `public-api 0.1.36`.
+Core bundles no plugins. Full includes `bishu-novel 0.2.2` and `public-api 0.1.37`.
 Use the first-run guide to configure your own model API or try the public model service.
 
 The macOS app is ad-hoc signed and has not been notarized by Apple. Drag it into Applications.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Core 不加载公益模型服务逻辑。
 | Windows x64 | `DeterminFlow_1.1.0_x64-setup.exe` | `DeterminFlow_1.1.0_x64-full-setup.exe` |
 | macOS Apple Silicon（M 系列芯片） | `DeterminFlow_1.1.0_aarch64.dmg` | `DeterminFlow_1.1.0_aarch64-full.dmg` |
 
-Core 不捆绑插件；Full 预装 `bishu-novel 0.2.2` 和 `public-api 0.1.36`。
+Core 不捆绑插件；Full 预装 `bishu-novel 0.2.2` 和 `public-api 0.1.37`。
 首次启动按引导配置自有模型 API，或选择公益模型体验。
 
 macOS 包采用 ad-hoc 签名，尚未经过 Apple 公证。将应用拖入“应用程序”后，若系统阻止打开，


### PR DESCRIPTION
Updates both READMEs to the public-api 0.1.37 version already pinned by the rebuilt Full installers. Documentation-only; validated against desktop/official-plugins.lock.json and git diff --check.